### PR TITLE
Initial support for a given language with an env variable

### DIFF
--- a/ansible/host_vars/vagrant
+++ b/ansible/host_vars/vagrant
@@ -35,7 +35,8 @@ wikidp_nginx_install: false
 # Set true to install uwsgi app server in pip mode
 wikidp_uwsgi_install: false
 
-# Wikidata user name and password
+# Wikidata user name, password and prefered language
 wikidata:
   user_name: "my_wikidata_user"
   password: "my_wikidata_password"
+  language: "my_wikidata_language"

--- a/ansible/roles/wikidp.portal/defaults/main.yml
+++ b/ansible/roles/wikidp.portal/defaults/main.yml
@@ -27,6 +27,7 @@ wikidp_nginx_conf_root: "/etc/nginx"
 wikidata:
   user_name: ""
   password: ""
+  language: "en"
 
 # Namespaced variables you'll unlikely change
 wikidp:

--- a/ansible/roles/wikidp.portal/templates/portal/bin/start.sh.j2
+++ b/ansible/roles/wikidp.portal/templates/portal/bin/start.sh.j2
@@ -2,5 +2,6 @@
 source "{{ wikidp.app.venv }}/bin/activate"
 export WIKIDP_BOT_USER='{{ wikidata.user_name }}'
 export WIKIDP_BOT_PASSWORD='{{ wikidata.password }}'
+export WIKIDP_LANG='{{ wikidata.language }}'
 export FLASK_APP='wikidp'
 flask run --port="{{ wikidp.flask.port }}" --host="{{ wikidp.flask.bind }}"

--- a/ansible/roles/wikidp.portal/templates/portal/home/pywikibot/user-config.py.j2
+++ b/ansible/roles/wikidp.portal/templates/portal/home/pywikibot/user-config.py.j2
@@ -1,4 +1,4 @@
-mylang = 'en'
+mylang = 'wikidata'
 family = 'wikidata'
 usernames[family][mylang] = u'{{ wikidata.user_name }}'
 

--- a/ansible/roles/wikidp.portal/templates/uwsgi/wikidp/home/bin/start.sh.j2
+++ b/ansible/roles/wikidp.portal/templates/uwsgi/wikidp/home/bin/start.sh.j2
@@ -2,4 +2,5 @@
 source "{{ wikidp.app.venv }}/bin/activate"
 export WIKIDP_BOT_USER='{{ wikidata.user_name }}'
 export WIKIDP_BOT_PASSWORD='{{ wikidata.password }}'
+export WIKIDP_LANG='{{ wikidata.language }}'
 uwsgi --socket "{{ wikidp.flask.bind }}:{{ wikidp.flask.port }}" --protocol=http --wsgi-file "{{ wikidp_git_local }}/wsgi.py" --callable APP -H "{{ wikidp.app.venv }}"

--- a/wikidp/DisplayFunctions.py
+++ b/wikidp/DisplayFunctions.py
@@ -24,17 +24,19 @@ import requests
 from wikidataintegrator import wdi_core
 
 from wikidp import APP
+from wikidp.const import ConfKey
 import wikidp.lists as LIST
 
 # Global Variables:
-LANG = 'en'
+LANG = APP.config[ConfKey.WIKIDATA_LANG]
+FALLBACK_LANG = APP.config[ConfKey.WIKIDATA_FB_LANG]
 URL_CACHE, PID_CACHE, QID_CACHE = {}, {}, {}
 CACHE_DIR = APP.config['CACHE_DIR']
 
 def search_result_list(string):
     """Uses wikidataintegrator to generate a list of similar items based on a text search
     and returns a list of (qid, Label, description, aliases) dictionaries"""
-    options = wdi_core.WDItemEngine.get_wd_search_results(string)
+    options = wdi_core.WDItemEngine.get_wd_search_results(string, language=LANG)
     if len(options) > 10:
         options = options[:10]
     output = []
@@ -48,7 +50,7 @@ def search_result_list(string):
     return output
 
 def item_detail_parse(qid):
-    """Uses the JSON representaion of wikidataintegrator to parse the item ID specified (qid)
+    """Uses the JSON representation of wikidataintegrator to parse the item ID specified (qid)
     and returns a new dictionary of previewing information and a dictionary of property counts"""
     try:
         item = wdi_core.WDItemEngine(wd_item_id=qid)
@@ -57,7 +59,7 @@ def item_detail_parse(qid):
         return None
     load_caches()
     global QID_CACHE
-    label = item.get_label()
+    label = item.get_label(lang=LANG) if item.get_label(lang=LANG) != '' else item.get_label(lang=FALLBACK_LANG)
     QID_CACHE[qid] = label
     item = item.wd_json_representation
     output_dict = {'label': [qid, label], 'claims':{}, 'refs':{},
@@ -65,11 +67,11 @@ def item_detail_parse(qid):
                    'categories':[], 'properties':[], 'prop-counts':{}}
     count_dict = {}
     try:
-        output_dict['aliases'] = [x['value'] for x in item['aliases'][LANG]]
+        output_dict['aliases'] = [x['value'] for x in item['aliases'].get(LANG) or item['aliases'][FALLBACK_LANG]]
     except:
         pass
     try:
-        output_dict['description'] = item['descriptions'][LANG]['value']
+        output_dict['description'] = [x['value'] for x in item['descriptions'].get(LANG) or item['descriptions'][FALLBACK_LANG]]
     except:
         pass
     for claim in item['claims']:
@@ -199,12 +201,13 @@ def _setup_cache_dir():
 
 def load_caches():
     """Uses pickle to load all caching files as global variables"""
-    logging.debug("Loading the caches")
+    logging.debug("Loading the caches with LANG %s", LANG)
     global URL_CACHE, PID_CACHE, QID_CACHE
 
     URL_CACHE = _pickle_cache_read("url-formats")
     PID_CACHE = _pickle_cache_read("property-labels")
     QID_CACHE = _pickle_cache_read("item-labels")
+    load_pid_labels()
 
 def _pickle_cache_read(cache_name):
     pickle_file = os.path.join(CACHE_DIR, cache_name)
@@ -244,7 +247,7 @@ def qid_label(qid):
         try:
             item = pywikibot.ItemPage(pywikibot.Site('wikidata', 'wikidata').data_repository(), qid)
             item.get()
-            label = item.labels[LANG]
+            label = item.labels.get(LANG, item.labels[FALLBACK_LANG]) # get the item in the language or in the fallback
             QID_CACHE[qid] = label
             _pickle_cache_persist("item-labels", QID_CACHE)
             return label
@@ -259,6 +262,31 @@ def qid_label(qid):
                 logging.exception("Unexpected exception finding QID label: %s", qid)
                 return "Unknown Item Label"
 
+def load_pid_labels():
+    """Load all the labels in LIST into the cache"""
+    global PID_CACHE
+    prop_list = LIST.properties()
+    ids = []
+    for prop in prop_list:
+        ids.append(prop[0])
+    try:
+        payload = {
+            'action': 'wbgetentities',
+            'ids': '|'.join(ids),
+            'languages': '|'.join([LANG, FALLBACK_LANG]),
+            'languagefallback': 'true',
+            'props': 'labels',
+            'format': 'json'
+        }
+        page = requests.get('https://www.wikidata.org/w/api.php', params=payload)
+        jpage = page.json()
+        for pid in jpage['entities']:
+            labels=jpage['entities'][pid]['labels']
+            title = labels.get(LANG, labels.get(FALLBACK_LANG))['value']
+            PID_CACHE[pid] = title
+    except:
+        logging.exception("Error loading properties in cache")
+
 def pid_label(pid):
     """Converts property identifier (P###) to a label and updates the cache"""
     global PID_CACHE
@@ -266,9 +294,20 @@ def pid_label(pid):
         return PID_CACHE[pid]
     except:
         try:
-            page = requests.get("http://wikidata.org/wiki/Property:"+pid)
-            title = html.fromstring(page.content).xpath('//title/text()')
-            title = title[0][:-10].title()
+            # Use the API in order to get the full Property in JSON with all the language alternatives
+            payload = {
+                'action': 'wbgetentities',
+                'ids': pid,
+                'languages': '|'.join([LANG, FALLBACK_LANG]),
+                'languagefallback': 'true',
+                'props': 'labels',
+                'format': 'json'
+            }
+            page = requests.get('https://www.wikidata.org/w/api.php', params=payload)
+            jpage = page.json()
+            labels=jpage['entities'][pid]['labels']
+            title = labels.get(LANG, labels.get(FALLBACK_LANG))['value']
+            # title = title[0][:-10]
             PID_CACHE[pid] = title
             return title
         except:
@@ -332,12 +371,13 @@ def caching_label(label_id, label, file_name):
 
 def qid_to_basic_details(qid):
     """Input item qid and returns a tuple: (qid, label, description) using WikiDataIntegrator"""
-    opt = wdi_core.WDItemEngine(wd_item_id=qid)
+    item = wdi_core.WDItemEngine(wd_item_id=qid)
+    label = item.get_label(lang=LANG) if item.get_label(lang=LANG) != '' else item.get_label(lang=FALLBACK_LANG)
     return {
-        "id": opt.wd_item_id,
-        "label": opt.get_label().replace("'", "&#39;"),
-        "description": opt.get_description().replace("'", "&#39;"),
-        "aliases": opt.get_aliases()
+        "id": item.wd_item_id,
+        "label": label.replace("'", "&#39;"),
+        "description": (item.get_description(lang=LANG) or item.get_description(lang=FALLBACK_LANG)).replace("'","&#39;"),
+        "aliases": item.get_aliases(lang=LANG) or item.get_aliases(lang=FALLBACK_LANG)
     }
 
 _setup_cache_dir()

--- a/wikidp/__init__.py
+++ b/wikidp/__init__.py
@@ -27,6 +27,8 @@ logging.basicConfig(filename=APP.config[ConfKey.LOG_FILE], level=logging.DEBUG,
                     format=APP.config[ConfKey.LOG_FORMAT])
 logging.info("Started Wiki-DP Portal app.")
 logging.debug("Configured logging.")
+logging.debug("Logging in directory %s", APP.config[ConfKey.LOG_FILE])
+logging.debug("Application configured with languages=%s", APP.config[ConfKey.WIKIBASE_LANGUAGE])
 
 # Import the application routes
 logging.info("Setting up application routes")

--- a/wikidp/config.py
+++ b/wikidp/config.py
@@ -27,6 +27,8 @@ class BaseConfig(object):
     SECRET_KEY = '7d441f27d441f27567d441f2b6176a'
     WIKIDATA_USER_NAME = 'username'
     WIKIDATA_PASSWORD = 'password'
+    WIKIDATA_LANG = 'en'
+    WIKIDATA_FB_LANG = 'en'
 
 class DevConfig(BaseConfig):
     """Developer level config, with debug logging and long log format."""
@@ -43,7 +45,14 @@ def configure_app(app):
     """Grabs the environment variable for app config or defaults to dev."""
     config_name = os.getenv('WIKIDP_CONFIG', 'dev')
     app.config.from_object(CONFIGS[config_name])
-    app.config.WIKIDATA_USER_NAME = os.getenv('WIKIDP_BOT_USER', BaseConfig.WIKIDATA_USER_NAME)
-    app.config.WIKIDATA_PASSWORD = os.getenv('WIKIDP_BOT_PASSWORD', BaseConfig.WIKIDATA_PASSWORD)
+    app.config['WIKIDATA_USER_NAME'] = os.getenv('WIKIDP_BOT_USER', BaseConfig.WIKIDATA_USER_NAME)
+    app.config['WIKIDATA_PASSWORD'] = os.getenv('WIKIDP_BOT_PASSWORD', BaseConfig.WIKIDATA_PASSWORD)
     if os.getenv('WIKIDP_CONFIG_FILE'):
         app.config.from_envvar('WIKIDP_CONFIG_FILE')
+    app.config['WIKIDATA_LANG'] = os.getenv('WIKIDP_LANG', BaseConfig.WIKIDATA_LANG)
+    app.config['WIKIDATA_FB_LANG'] = os.getenv('WIKIDP_FB_LANG', BaseConfig.WIKIDATA_FB_LANG)
+    # Create the list of unique languages to easy SPARQL queries
+    if app.config['WIKIDATA_LANG'] != app.config['WIKIDATA_FB_LANG']:
+        app.config['WIKIBASE_LANGUAGE'] = ",".join([app.config['WIKIDATA_LANG'], app.config['WIKIDATA_FB_LANG']])
+    else:
+        app.config['WIKIBASE_LANGUAGE'] = app.config['WIKIDATA_LANG']

--- a/wikidp/const.py
+++ b/wikidp/const.py
@@ -15,6 +15,9 @@ than multiple hardcoded strings in code.
 """
 
 class ConfKey(object):
-    """Config key string constatnts"""
+    """Config key string constants"""
     LOG_FORMAT = 'LOG_FORMAT'
     LOG_FILE = 'LOG_FILE'
+    WIKIDATA_LANG = 'WIKIDATA_LANG'
+    WIKIDATA_FB_LANG = 'WIKIDATA_FB_LANG'
+    WIKIBASE_LANGUAGE = 'WIKIBASE_LANGUAGE'

--- a/wikidp/controller.py
+++ b/wikidp/controller.py
@@ -15,6 +15,7 @@ import re
 
 from flask import render_template, request, json
 from wikidp import APP
+from wikidp.const import ConfKey
 from wikidp.model import FileFormat, PuidSearchResult
 from wikidp.lists import properties
 import wikidp.DisplayFunctions as DF
@@ -37,7 +38,7 @@ def reports():
 @APP.route("/browse")
 def list_extensions():
     """Displays a list of extensions and media types."""
-    formats = FileFormat.list_formats()
+    formats = FileFormat.list_formats(lang = APP.config[ConfKey.WIKIBASE_LANGUAGE])
     return render_template('browse.html', formats=formats)
 
 @APP.route("/puid/<string:puid>")
@@ -45,7 +46,7 @@ def search_puid(puid):
     """Displays a list of extensions and media types."""
     puid = puid.replace('_', '/')
     logging.debug("Searching for PUID: %s", puid)
-    results = PuidSearchResult.search_puid(puid)
+    results = PuidSearchResult.search_puid(puid, lang = APP.config[ConfKey.WIKIBASE_LANGUAGE])
     return render_template('puid_results.html', results=results, puid=puid)
 
 @APP.route("/search", methods=['POST'])
@@ -55,7 +56,7 @@ def search_results_page():
     # Check if searching with PUID
     try:
         if re.search("[x-]?fmt/\d+", _input) != None:
-            result = PuidSearchResult.search_puid( _input)
+            result = PuidSearchResult.search_puid( _input, lang = APP.config[ConfKey.WIKIBASE_LANGUAGE])
             for res in result:
                 item = DF.qid_to_basic_details(res.format)
                 options = [[res.format, res.label, item['description']]]

--- a/wikidp/model.py
+++ b/wikidp/model.py
@@ -48,21 +48,20 @@ class FileFormat(object):
         return "".join(ret_val)
 
     @classmethod
-    def list_formats(cls):
-        """Queries Wikdata for formats and returns a list of FileFormat instances."""
+    def list_formats(cls, lang="en"):
+        """Queries Wikidata for formats and returns a list of FileFormat instances."""
         query = [
-            "SELECT DISTINCT ?idFileFormat ?idFileFormatLabel",
-            "(GROUP_CONCAT(DISTINCT ?mediaType; SEPARATOR="|") AS ?mediaTypes)",
+            "SELECT ?idFileFormat ?idFileFormatLabel",
+            "(GROUP_CONCAT(DISTINCT ?mediaType; SEPARATOR='|') AS ?mediaTypes)",
             "WHERE {",
-            "?idFileFormat wdt:P31 wd:Q235557",
-            "OPTIONAL {",
-            "?idFileFormat wdt:P1163 ?mediaType .}",
-            "SERVICE wikibase:label { bd:serviceParam wikibase:language 'en' }",
+            "?idFileFormat wdt:P31 wd:Q235557.",
+            "OPTIONAL { ?idFileFormat wdt:P1163 ?mediaType }",
+            "SERVICE wikibase:label {{ bd:serviceParam wikibase:language  '{}' }}".format(lang),
             "}",
             "GROUP BY ?idFileFormat ?idFileFormatLabel",
             "ORDER BY ?idFileFormatLabel"
             ]
-        results_json = wdi_core.WDItemEngine.execute_sparql_query("".join(query))
+        results_json = wdi_core.WDItemEngine.execute_sparql_query(" ".join(query))
         results = [cls(x['idFileFormat']['value'].replace('http://www.wikidata.org/entity/', ''),
                        x['idFileFormatLabel']['value'],
                        x['mediaTypes']['value'].split('|'))
@@ -129,15 +128,15 @@ class PuidSearchResult(object):
     @staticmethod
     def _concat_query(values_clause="", lang="en"):
         query = [
-            "SELECT DISTINCT ?format ?formatLabel ?mime ?puid ",
+            "SELECT DISTINCT ?format ?formatLabel ?mime ?puid",
             "WHERE {",
             "?format wdt:P2748 ?puid.",
             "?format wdt:P1163 ?mime.",
-            "SERVICE wikibase:label {{bd:serviceParam wikibase:language '{}'}}".format(lang)
+            "SERVICE wikibase:label {{ bd:serviceParam wikibase:language '{}' }}".format(lang)
             ]
         query.append(values_clause)
         query.append("}")
-        return "".join(query)
+        return " ".join(query)
 
     @staticmethod
     def _assemble_results(results_json):

--- a/wikidp/templates/reports.html
+++ b/wikidp/templates/reports.html
@@ -14,56 +14,116 @@
     </div>
     <ul>
       <li>
-        <div class="query-title" onclick="$(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
-          Number of software titles recorded
+        <div class="query-title" onclick="addQuery('query1', 1); $(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
+          Number of software titles recorded <span id="count1" />
         </div>
         <div class="wd-iframe-container" hidden>
-          <iframe src="https://query.wikidata.org/embed.html#SELECT%20DISTINCT%20%3Fapp%20%3FappLabel%20%0AWHERE%20%7B%0A%20%20%3Fapp%20wdt%3AP31%2Fwdt%3AP279*%20wd%3AQ7397.%0A%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+          <iframe name="query1" id="query1" style="width: 80vw; height: 50vh; border: none;" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
         </div>
       </li>
       <li>
-        <div class="query-title" onclick="$(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
-          Number of file formats recorded
+        <div class="query-title" onclick="addQuery('query2', 2); $(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
+          Number of file formats recorded <span id="count2" />
         </div>
         <div class="wd-iframe-container" hidden>
-          <iframe src="https://query.wikidata.org/#SELECT%20DISTINCT%20%3Fapp%20%3FappLabel%20%0AWHERE%20%7B%0A%20%20%3Fapp%20wdt%3AP31%2Fwdt%3AP279%2A%20wd%3AQ235557.%0A%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+          <iframe name="query2" id="query2" style="width: 80vw; height: 50vh; border: none;" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
         </div>
       </li>
       <li>
-        <div class="query-title" onclick="$(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
-          Number of PRONOM Unique Identifiers recorded
+        <div class="query-title" onclick="addQuery('query3', 3); $(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
+          Number of PRONOM Unique Identifiers recorded <span id="count3" />
         </div>
         <div class="wd-iframe-container" hidden>
-          <iframe src="https://query.wikidata.org/#SELECT%20DISTINCT%20%3Fformat%20%3FformatLabel%20%3Fpuid%0AWHERE%20%7B%0A%20%20%3Fformat%20wdt%3AP2748%20%3Fpuid%20.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%09%09bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22%20.%0A%7D%0A%20%20%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+          <iframe name="query3" id="query3" style="width: 80vw; height: 50vh; border: none;" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
         </div>
       </li>
       <li>
-        <div class="query-title" onclick="$(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
-          Number of file signatures described
+        <div class="query-title" onclick="addQuery('query4', 4); $(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
+          Number of file signatures described <span id="count4" />
         </div>
         <div class="wd-iframe-container" hidden>
-          <iframe src="https://query.wikidata.org/#SELECT%20%3Fitem%20%3FitemLabel%20%3FvalueLabel%0A%7B%0A%09%3Fitem%20wdt%3AP4152%20%3Fvalue%20.%0A%09SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%2Cen%22%20%20%7D%20%20%20%20%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+          <iframe name="query4" id="query4" style="width: 80vw; height: 50vh; border: none;" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
         </div>
       </li>
       <li>
-        <div class="query-title" onclick="$(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
-          Number of emulators recorded
+        <div class="query-title" onclick="addQuery('query5', 5); $(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
+          Number of emulators recorded <span id="count5" />
         </div>
         <div class="wd-iframe-container" hidden>
-          <iframe src="https://query.wikidata.org/#SELECT%20%3Femulator%20%3FemulatorLabel%0AWHERE%20%7B%0A%20%20%3Femulator%20wdt%3AP31%2Fwdt%3AP279%2A%20wd%3AQ202871%20.%20%20%20%20%20%20%20%20%20%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%0A%09%09bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22%20.%0A%7D%0A%20%20%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+          <iframe name="query5" id="query5" style="width: 80vw; height: 50vh; border: none;" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
         </div>
       </li>
       <li>
-        <div class="query-title" onclick="$(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
-          Number of file systems recorded
+        <div class="query-title" onclick="addQuery('query6', 6); $(this).next().animate({height: 'toggle', opacity: 'toggle',}, 'slow')">
+          Number of file systems recorded <span id="count6" />
         </div>
         <div class="wd-iframe-container" hidden>
-          <iframe src="https://query.wikidata.org/#SELECT%20%3Fitem%20%3FitemLabel%20%0AWHERE%20%0A%7B%0A%20%20%3Fitem%20wdt%3AP31%2Fwdt%3AP279%2A%20wd%3AQ174989.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22%5BAUTO_LANGUAGE%5D%2Cen%22.%20%7D%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+          <iframe name="query6" id="query6" style="width: 80vw; height: 50vh; border: none;" src="" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
         </div>
       </li>
     </ul></div>
 </div>
   <script type="text/javascript">
+    var endpointUrl = 'https://query.wikidata.org/sparql';
+    var endpointEmbedUrl = 'https://query.wikidata.org/embed.html#';
+    var sparqlQueries = [
+      "SELECT ?item ?itemLabel \n" +
+      "WHERE { \n" +
+      "  ?item wdt:P31/wdt:P279* wd:Q7397. \n"
+    ,
+      "SELECT ?item ?itemLabel \n" +
+      "WHERE { \n" +
+      "  ?item wdt:P31/wdt:P279* wd:Q235557. \n"
+    ,
+      "SELECT ?item ?itemLabel ?puid \n" +
+      "WHERE { \n" +
+      "  ?item wdt:P2748 ?puid. \n"
+    ,
+      "SELECT ?item ?itemLabel ?signature ?encodingLabel \n" +
+      "WHERE { \n" +
+      "  ?item wdt:P31/wdt:P279* wd:Q235557. \n" +
+      "  ?item p:P4152 ?signatureStmt. \n" +
+      "  ?signatureStmt ps:P4152 ?signature. \n" +
+      "  ?signatureStmt pq:P3294 ?encoding. \n"
+    ,
+      "SELECT ?item ?itemLabel \n" +
+      "WHERE { \n" +
+      "  ?item wdt:P31/wdt:P279* wd:Q202871. \n"
+    ,
+      "SELECT ?item ?itemLabel \n" +
+      "WHERE { \n" +
+      "    ?item wdt:P31/wdt:P279* wd:Q174989. \n"
+    ];
+
+    var labelServiceStmt =
+      "  SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\". } ";
+    var limitStmt = " LIMIT 100";
+
+    function addQuery(iframeName, number) {
+      var $iframe = $('#' + iframeName);
+      if ( $iframe.length ) {
+        var isThereAQuery = $iframe.attr('src');
+        if ( isThereAQuery == '') {
+          // First time : the query has to be run
+          // Make a first request to COUNT the number of items
+          var countQuery = "SELECT (COUNT(*) AS ?number) WHERE { " +
+            sparqlQueries[number - 1] + labelServiceStmt + " } " + "}";
+          var settings = {
+            headers: { Accept: 'application/sparql-results+json' },
+            data: { query: countQuery }
+          };
+          $.ajax( endpointUrl, settings ).then( function ( data ) {
+              var counter = data['results']['bindings'][0]['number']['value'];
+              $('#count' + number).text("(" + counter + ")");
+              // Embed the query and show the first 100 items
+              var query = sparqlQueries[number - 1] + labelServiceStmt + " } " + limitStmt;
+              $iframe.attr('src', encodeURI(endpointEmbedUrl + query));
+          } );
+          return false;
+        }
+      }
+      return true;
+    }
 
     $("form").submit(function(){
     $('div.page-container').fadeOut(500);


### PR DESCRIPTION
Add WIKIDP_LANG env for defining the default language.
Take care of a fallback language when nothing is defined in the default one.
Correct SPARQL queries by putting a space in the join.
Use the wbgetentities API to retrieve labels for properties to get various language
instead of going to the web page with only English in it.
Fill the cache of properties on init.
Correct the config to be able to define the default language and the fallback one.
