### PR TITLE
Feat/ui: First step at UI writes to test wikidata 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,14 +100,23 @@ ENV/
 /site
 
 # Application odds and ends
+.pytest_cache/
 apicache/
+apicache-py3/
 throttle.ctrl
 user-config.py
 caches/
 wikidp/idjc-paper.pages
+pywikibot.lwp
 
 # Ingore all vagrant artifacts
 .vagrant*
+
+# Ignore Ansible build directories
+ansible/roles/nginxinc.nginx/
+ansible/roles/tersmitten.apt/
+ansible/roles/tersmitten.timezone/
+ansible/roles/tschifftner.hostname/
 
 # Ignore Ansible retry files
 ansible/*.retry

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ wikidp/idjc-paper.pages
 
 # Ignore Ansible retry files
 ansible/*.retry
+
+# MAC OS Hidden Files
+.DS_Store

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,32 @@ If you find an item for a software developer that does not yet have many stateme
 Follow the link from the value for [MobyGames company ID](https://www.wikidata.org/wiki/Property:P4773) on the item for the developer to see the Moby Games page for the company. Thank you for making the information in Wikidata more complete! 
 
 Here is a SPARQL query to find all Wikidata items that have a statment using [MobyGames company ID](https://www.wikidata.org/wiki/Property:P4773). Copy the text of the query and paste it into the [Wikidata Query Service SPARQL endpoint](https://query.wikidata.org).
+### Adding external id info to software items
 
+External id properties have their own data type and are used to link out to datasets beyond Wikidata.
+
+   [AUR package (P4162)](https://www.wikidata.org/wiki/Property:P4162)
+    [Arch Linux package (P3454)](https://www.wikidata.org/wiki/Property:P3454)
+   [Debian stable package (P3442)](https://www.wikidata.org/wiki/Property:P3442)
+   [DistroWatch ID (P3112)](https://www.wikidata.org/wiki/Property:P3112)
+    [F-Droid package (P3597)](https://www.wikidata.org/wiki/Property:P3597)
+    [Fedora package (P3463)](https://www.wikidata.org/wiki/Property:P3463)
+    [Framalibre ID (P4107)](https://www.wikidata.org/wiki/Property:P4107)
+    [Free Software Directory entry](https://www.wikidata.org/wiki/Property:P2537)
+    [Gentoo package (P3499)](https://www.wikidata.org/wiki/Property:P3499)
+    [Google Play Store App ID (P3418)](https://www.wikidata.org/wiki/Property:P3418)
+    [Hall of Light Amiga database ID (P4671)](https://www.wikidata.org/wiki/Property:P4671)
+    [MAC Address Block Large ID (P4776)](https://www.wikidata.org/wiki/Property:P4776)
+    [Nintendo Game Store ID (P4685)](https://www.wikidata.org/wiki/Property:P4685)
+    [PRONOM software identifier (P2749)](https://www.wikidata.org/wiki/Property:P2749)
+    [Rosetta Code ID (P5047)](https://www.wikidata.org/wiki/Property:P5407)
+    [SourceForge project (P2209)](https://www.wikidata.org/wiki/Property:P2209)
+    [Stack Exchange tag (P1482)]
+    [Twitter hashtag (P2572)]
+    [Ubuntu package (P3473)]
+    [Uniform Resource Identifier Scheme (P4742)]
+    [crates.io ID (P4763)]
+    [snap package (P4435)]
 ### Work from a list
 
 [File formats with info from Just Solve Wiki](https://www.wikidata.org/wiki/User:YULdigitalpreservation/FileFormatsList)

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ If you find an item for a software developer that does not yet have many stateme
 
 Follow the link from the value for [MobyGames company ID](https://www.wikidata.org/wiki/Property:P4773) on the item for the developer to see the Moby Games page for the company. Thank you for making the information in Wikidata more complete! 
 
-Here is a SPARQL query to find all Wikidata items that have a statment using [MobyGames company ID](https://www.wikidata.org/wiki/Property:P4773). Copy the text of the query and paste it into the Wikidata Query Service SPARQL endpoint.
+Here is a SPARQL query to find all Wikidata items that have a statment using [MobyGames company ID](https://www.wikidata.org/wiki/Property:P4773). Copy the text of the query and paste it into the [Wikidata Query Service SPARQL endpoint](https://query.wikidata.org).
 
 ### Work from a list
 

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,13 @@ setup(
     include_package_data=True,
     install_requires=[
         'flask==0.12.2',
-        'wikidataintegrator==0.0.481',
+        'wikidataintegrator',
         'lxml==3.7.3',
-        'pywikibot==3.0.20180204'
+        'pandas',
+        'pywikibot',
+        'pylint',
+        'pytest',
+        'tqdm'
         #
         # carl@openpreservation.org removed these dependencies as almost certainly
         # unused on 2nd Oct 2017, commenting for safety.

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+
+from unittest import TestCase
+
+from wikidataintegrator import wdi_core
+from wikidataintegrator.wdi_core import WDItemEngine
+
+from wikidp.model import FileFormat, PuidSearchResult
+
+class WikidataTests(TestCase):
+    def test_format_read(self):
+        """Queries Wikidata for formats and returns a list of FileFormat instances."""
+        results = FileFormat.list_formats()
+        assert len(results) > 0, \
+        'Format read returned no results'
+
+    def test_sandbox_mime_read(self):
+        mediawiki_api_url = 'https://test.wikidata.org/w/api.php'
+        sparql_endpoint_url = 'https://test.wikidata.org/proxy/wdqs/bigdata/namespace/wdq/sparql'
+        wiki_sandbox = WDItemEngine.wikibase_item_engine_factory(mediawiki_api_url, sparql_endpoint_url)
+        sandbox_results = PuidSearchTest.search_mime(wiki_sandbox, "text/plain")
+        results = PuidSearchTest.search_mime(wdi_core.WDItemEngine, "text/plain")
+        assert len(sandbox_results) == len(results), \
+        'There should be no PUID results in the sandbox.'
+
+    def test_item_write(self):
+        assert True
+
+class PuidSearchTest(object):
+    """Encapsulates a file format plus widata query magic for formats."""
+    def __init__(self, wd_format, label, mime, puid):
+        self._format = wd_format
+        self._label = label
+        self._mime = mime
+        self._puid = puid
+
+    @property
+    def format(self):
+        """The wikidata item the format field."""
+        return self._format
+
+    @property
+    def label(self):
+        """The formats WikiData label."""
+        return self._label
+
+    @property
+    def mime(self):
+        """The MIME type of the format."""
+        return self._mime
+
+    @property
+    def puid(self):
+        """The PUID of the format."""
+        return self._puid
+
+    def __str__(self):
+        ret_val = []
+        ret_val.append("PuidSearchResult : [format=")
+        ret_val.append(self.format)
+        ret_val.append(", label=")
+        ret_val.append(self.label)
+        ret_val.append(", MIME=")
+        ret_val.append(self.mime)
+        ret_val.append(", puid=")
+        ret_val.append(self.puid)
+        ret_val.append("]")
+        return "".join(ret_val)
+
+    @classmethod
+    def search_puid(cls, wdengine, puid, lang="en"):
+        """Queries Wikdata for formats and returns a list of FileFormat instances."""
+        query = cls._concat_query("VALUES ?puid {{ '{}' }}".format(puid), lang)
+        results_json = wdengine.execute_sparql_query(query)
+        return cls._assemble_results(results_json)
+
+    @classmethod
+    def search_mime(cls, wdengine, mime, lang="en"):
+        """Queries Wikdata for formats and returns a list of FileFormat instances."""
+        query = cls._concat_query("VALUES ?mime {{ '{}' }}".format(mime), lang)
+        results_json = wdengine.execute_sparql_query(query)
+        return cls._assemble_results(results_json)
+
+    @staticmethod
+    def _concat_query(values_clause="", lang="en"):
+        query = [
+            "SELECT DISTINCT ?format ?formatLabel ?mime ?puid",
+            "WHERE {",
+            "?format wdt:P2748 ?puid.",
+            "?format wdt:P1163 ?mime.",
+            "SERVICE wikibase:label {{ bd:serviceParam wikibase:language '{}' }}".format(lang)
+            ]
+        query.append(values_clause)
+        query.append("}")
+        return " ".join(query)
+
+    @staticmethod
+    def _assemble_results(results_json):
+        results = [PuidSearchResult(
+            x['format']['value'].replace('http://www.wikidata.org/entity/', ''),
+            x['formatLabel']['value'],
+            x['mime']['value'],
+            x['puid']['value'])
+                   for x in results_json['results']['bindings']]
+        return results

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -9,107 +9,33 @@
 # License, Version 3. See the text file "COPYING" for further details
 # about the terms of this license.
 #
-
+"""Unit tests for WikiData reads."""
 from unittest import TestCase
+
+import pywikibot
 
 from wikidataintegrator import wdi_core
 from wikidataintegrator.wdi_core import WDItemEngine
 
 from wikidp.model import FileFormat, PuidSearchResult
+SANDBOX_API_URL = 'https://test.wikidata.org/w/'
+SANDBOX_SPARQL_URL = 'https://test.wikidata.org/proxy/wdqs/bigdata/namespace/wdq/'
+SITE = pywikibot.Site("test", "wikidata")
+REPO = SITE.data_repository()
 
 class WikidataTests(TestCase):
     def test_format_read(self):
         """Queries Wikidata for formats and returns a list of FileFormat instances."""
         results = FileFormat.list_formats()
-        assert len(results) > 0, \
+        assert results, \
         'Format read returned no results'
 
-    def test_sandbox_mime_read(self):
-        mediawiki_api_url = 'https://test.wikidata.org/w/api.php'
-        sparql_endpoint_url = 'https://test.wikidata.org/proxy/wdqs/bigdata/namespace/wdq/sparql'
-        wiki_sandbox = WDItemEngine.wikibase_item_engine_factory(mediawiki_api_url, sparql_endpoint_url)
-        sandbox_results = PuidSearchTest.search_mime(wiki_sandbox, "text/plain")
-        results = PuidSearchTest.search_mime(wdi_core.WDItemEngine, "text/plain")
-        assert len(sandbox_results) == len(results), \
-        'There should be no PUID results in the sandbox.'
-
-    def test_item_write(self):
-        assert True
-
-class PuidSearchTest(object):
-    """Encapsulates a file format plus widata query magic for formats."""
-    def __init__(self, wd_format, label, mime, puid):
-        self._format = wd_format
-        self._label = label
-        self._mime = mime
-        self._puid = puid
-
-    @property
-    def format(self):
-        """The wikidata item the format field."""
-        return self._format
-
-    @property
-    def label(self):
-        """The formats WikiData label."""
-        return self._label
-
-    @property
-    def mime(self):
-        """The MIME type of the format."""
-        return self._mime
-
-    @property
-    def puid(self):
-        """The PUID of the format."""
-        return self._puid
-
-    def __str__(self):
-        ret_val = []
-        ret_val.append("PuidSearchResult : [format=")
-        ret_val.append(self.format)
-        ret_val.append(", label=")
-        ret_val.append(self.label)
-        ret_val.append(", MIME=")
-        ret_val.append(self.mime)
-        ret_val.append(", puid=")
-        ret_val.append(self.puid)
-        ret_val.append("]")
-        return "".join(ret_val)
-
-    @classmethod
-    def search_puid(cls, wdengine, puid, lang="en"):
-        """Queries Wikdata for formats and returns a list of FileFormat instances."""
-        query = cls._concat_query("VALUES ?puid {{ '{}' }}".format(puid), lang)
-        results_json = wdengine.execute_sparql_query(query)
-        return cls._assemble_results(results_json)
-
-    @classmethod
-    def search_mime(cls, wdengine, mime, lang="en"):
-        """Queries Wikdata for formats and returns a list of FileFormat instances."""
-        query = cls._concat_query("VALUES ?mime {{ '{}' }}".format(mime), lang)
-        results_json = wdengine.execute_sparql_query(query)
-        return cls._assemble_results(results_json)
-
-    @staticmethod
-    def _concat_query(values_clause="", lang="en"):
-        query = [
-            "SELECT DISTINCT ?format ?formatLabel ?mime ?puid",
-            "WHERE {",
-            "?format wdt:P2748 ?puid.",
-            "?format wdt:P1163 ?mime.",
-            "SERVICE wikibase:label {{ bd:serviceParam wikibase:language '{}' }}".format(lang)
-            ]
-        query.append(values_clause)
-        query.append("}")
-        return " ".join(query)
-
-    @staticmethod
-    def _assemble_results(results_json):
-        results = [PuidSearchResult(
-            x['format']['value'].replace('http://www.wikidata.org/entity/', ''),
-            x['formatLabel']['value'],
-            x['mime']['value'],
-            x['puid']['value'])
-                   for x in results_json['results']['bindings']]
-        return results
+    def test_new_item(self):
+        new_item = pywikibot.ItemPage(SITE)
+        labels = {"en": "Carl Wilson", "de": "Carl Wilson"}
+        new_item.editLabels(labels=labels, summary="Adding labels")
+        my_item_id = new_item.getID()
+        item = pywikibot.ItemPage(REPO, my_item_id)
+        item.get()
+        assert item.labels['en'] == 'Carl Wilson'
+        assert item.labels['de'] == 'Carl Wilson'

--- a/wikidp/controller.py
+++ b/wikidp/controller.py
@@ -19,7 +19,7 @@ from wikidp.const import ConfKey
 from wikidp.model import FileFormat, PuidSearchResult
 from wikidp.lists import properties
 import wikidp.DisplayFunctions as DF
-
+from wikidp.controllers.api import *
 @APP.route("/")
 def welcome():
     """Landing Page for first time"""

--- a/wikidp/controller.py
+++ b/wikidp/controller.py
@@ -91,7 +91,7 @@ def selected_item(id):
     else:
         basic_details = DF.qid_to_basic_details(qid)
         options = [[qid, basic_details['label'], basic_details['description']]]
-    return render_template('preview-item.html', selected=preview_item, options=options)
+    return render_template('preview-item.html', selected=preview_item, options=options, page='preview')
 
 @APP.route("/contribute", methods=['POST'])
 def process_contribute_url():
@@ -109,7 +109,7 @@ def contribute_selected_page():
     else:
         basic_details = DF.qid_to_basic_details(qid)
         options = [[qid, basic_details['label'], basic_details['description']]]
-    return render_template('contribute.html', selected=preview_item, options=options)
+    return render_template('contribute.html', selected=preview_item, options=options, page='contribute')
 
 
 @APP.route("/api-load-item", methods=['POST'])

--- a/wikidp/controllers/api.py
+++ b/wikidp/controllers/api.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+""" Flask application routes for Wikidata portal. """
+import logging
+import re
+
+from flask import render_template, request, json, redirect
+from wikidp import APP
+from wikidp.const import ConfKey
+from wikidp.model import FileFormat, PuidSearchResult
+from wikidp.lists import properties
+import wikidp.DisplayFunctions as DF
+from wikidp.controllers import wd_write
+@APP.route("/api/")
+def api_welcome():
+    """Landing Page API index"""
+    return 'Welcome to the WikiDP API'
+
+@APP.route("/api/<qid>/claims/write", methods=['POST'])
+def api_write_claims_to_item(qid):
+    logging.debug("Processing user POST request.")
+    user_claims = request.get_json()
+    successful_claims, failure_claims = [], []
+    for user_claim in user_claims:
+        write_status = wd_write.write_claim(qid, user_claim['pid'], user_claim['value'])
+        if write_status is True:
+            successful_claims.append(user_claim)
+        else:
+            failure_claims.append(user_claim)
+    output = {'status': 'success', 'successful_claims': successful_claims, 'failure_claims':failure_claims}
+    return json.dumps(output)
+
+# TODO: Add the rest of the api routes to this file instead of the main controller.py

--- a/wikidp/controllers/wd_write.py
+++ b/wikidp/controllers/wd_write.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+"""Controller functions for writing to wikidata."""
+
+import pywikibot
+SANDBOX_API_URL = 'https://test.wikidata.org/w/'
+SANDBOX_SPARQL_URL = 'https://test.wikidata.org/proxy/wdqs/bigdata/namespace/wdq/'
+SITE = pywikibot.Site("test", "wikidata")
+REPO = SITE.data_repository()
+
+def write_claim(qid, property, value, meta=False):
+    '''Function for writing a claim to WikiData
+
+    Args:
+        qid (str): Wikidata Item Identifier [ex. 'Q1234']
+        property (str): Wikidata Property Identifier [ex. 'P1234']
+        value (str): Value matching accepted property type (could be other datatypes)
+        meta (dict, optional): Contains information about qualifiers/references/summaries
+    Returns:
+        bool: True if successful, False otherwise
+    '''
+    try:
+        # TODO: Convert to writes to any item by uncommenting line 34
+        item = pywikibot.ItemPage(REPO, u"Q175461") # WIKIDATA TESTING ITEM
+        # item = pywikibot.ItemPage(REPO, qid)
+        claim = pywikibot.Claim(REPO, property)
+        target = pywikibot.ItemPage(REPO, value)
+        claim.setTarget(target)
+        item.addClaim(claim, summary=u'Adding claim')
+        return True
+    except Exception as e:
+        return False

--- a/wikidp/lists.py
+++ b/wikidp/lists.py
@@ -17,18 +17,18 @@ def properties():
     				 ]
     property_values = ["P31", "P361", "P144", "P1365", "P178"]
     return softwareList
-        fileFormatList = [("P856", "url"),
-    				 ("P178", "item"),
-                     ("P577", "date"),    
-                     ("P348", "string"),
-    				 ("P1195", "string"),
-                     ("P1163", "string"),
-    				 ("P144", "item"),
-    				 ("P4152", "string"),
-    				 ("P2748", "ex-id"),
-    				 ("P3266", "string"),
-                     ("P973", "item"),     
-    				 ("P3381", "string")
+    fileFormatList = [("P856", "url"),
+				 ("P178", "item"),
+                 ("P577", "date"),
+                 ("P348", "string"),
+				 ("P1195", "string"),
+                 ("P1163", "string"),
+				 ("P144", "item"),
+				 ("P4152", "string"),
+				 ("P2748", "ex-id"),
+				 ("P3266", "string"),
+                 ("P973", "item"),
+				 ("P3381", "string")
     				 ]
     property_values = ["P31", "P361", "P144", "P178"]
     return fileFormatList

--- a/wikidp/lists.py
+++ b/wikidp/lists.py
@@ -18,17 +18,17 @@ def properties():
     property_values = ["P31", "P361", "P144", "P1365", "P178"]
     return softwareList
     fileFormatList = [("P856", "url"),
-				 ("P178", "item"),
-                 ("P577", "date"),
-                 ("P348", "string"),
-				 ("P1195", "string"),
-                 ("P1163", "string"),
-				 ("P144", "item"),
-				 ("P4152", "string"),
-				 ("P2748", "ex-id"),
-				 ("P3266", "string"),
-                 ("P973", "item"),
-				 ("P3381", "string")
+    				 ("P178", "item"),
+                     ("P577", "date"),
+                     ("P348", "string"),
+    				 ("P1195", "string"),
+                     ("P1163", "string"),
+    				 ("P144", "item"),
+    				 ("P4152", "string"),
+    				 ("P2748", "ex-id"),
+    				 ("P3266", "string"),
+                     ("P973", "item"),
+    				 ("P3381", "string")
     				 ]
     property_values = ["P31", "P361", "P144", "P178"]
     return fileFormatList

--- a/wikidp/static/css/wikidp.css
+++ b/wikidp/static/css/wikidp.css
@@ -123,12 +123,11 @@ a.wd-id {
 	}
 
 	ul#search-option-list {
-	    list-style: none;
-	    padding: 0;
-		margin: 0 auto;
-    	width: 80%;
-	    max-height: 350px;
-        overflow-y: scroll;
+			list-style: none;
+			padding: 0;
+			margin: 0 auto;
+			margin-bottom: 200px;
+			width: 80%;
 	}
 
 	ul#search-option-list li {

--- a/wikidp/static/css/wikidp.css
+++ b/wikidp/static/css/wikidp.css
@@ -210,7 +210,7 @@ div#panel-frame.contribute-page div#sidebar-frame {
 
 div#sidebar-div {
     height: 100%;
-    padding: 10px 0;
+    padding: 0;
     position: relative;
 }
 div#sidebar-frame select#option-select {
@@ -326,18 +326,18 @@ li.sidebar-property-li.property-ok {
 
 .actions-div {
 	width: 100%;
-    padding: 15px 0 0 0;
-    font-size: 20px;
-    font-weight: 600;
-    position: absolute;
-    bottom: 0;
-
-
+	padding: 0;
+	font-size: 20px;
+	margin-bottom: 15px;
+	font-weight: 600;
+	/* position: absolute; */
+	/* bottom: 0; */
 }
 
 li.sidebar-action-li {
     background: #444646;
     padding: 10px;
+    color: lightgrey;
 }
 div.actions-div ul#sidebar-action-list {
 	cursor: pointer;

--- a/wikidp/static/css/wikidp.css
+++ b/wikidp/static/css/wikidp.css
@@ -269,9 +269,12 @@ div#sidebar-property-scroller {
 .property-overview-div li {
     display: block;
     color: rgb(255, 255, 255);
-    text-align: right;
+    text-align: left;
 }
-
+.sidebar-property-count {
+    display: inline;
+    float: right;
+}
 .property-overview-div li:before
 {
     /*Using a Bootstrap glyphicon as the bullet point*/
@@ -522,10 +525,18 @@ div#creation-div {
     height: 100px;
     /* border-bottom: 1px solid; */
     margin-bottom: 15px;
-    opacity: .5;
+    opacity: 1;
 }
 div#creation-div:hover, div#creation-div:focus {
     opacity: 1;
+}
+button#saveClaimsBtn {
+    background: none;
+    color: white;
+    border: 2px solid;
+    padding: 19px 20%;
+    font-weight: bold;
+    margin: 50px 0 100px;
 }
 input#claim-value {
     width: calc(80% - 30px);

--- a/wikidp/templates/contribute.html
+++ b/wikidp/templates/contribute.html
@@ -17,7 +17,7 @@
           <select id="create-claim-property">
             <option class="default" data-type="default" >select a property</option>
             {% for property in selected['properties'] %}
-              <option class="" data-pid="{{property[0]}}" data-count="{{property[2]}}" data-type="{{property[3]}}">
+              <option class="" value="{{property[0]}}"  data-pid="{{property[0]}}" data-count="{{property[2]}}" data-type="{{property[3]}}">
                 {{property[1]}}
               </option>
             {% endfor %}
@@ -28,6 +28,7 @@
       <div id="claims-list">
         <span class="creation-section-header">MY CLAIMS</span><br>
         <ul id="added-claims">
+          <li id="saveClaimsLi" style="display:none"> <button id="saveClaimsBtn" onclick="save_claims()">SAVE TO WIKIDATA</button></li>
         </ul>
       </div>
     </div>
@@ -49,8 +50,13 @@
       form.submit();
     })
   }
+  $('.sidebar-property-li').click(function(){
+    $('#create-claim-property').val($(this).data('pid'));
+    initializeClaim();
+  })
+  function initializeClaim(){
+   var type = $('select#create-claim-property :selected').data('type');
 
-  function initializeClaim(type){
     $('select#create-claim-property option.default').prop('disabled', true)
     console.log('...initialing data-type: '+type);
     var div = $('div#create-claim-value-div').fadeOut(400, function(){
@@ -122,7 +128,7 @@
   })
 
   $('select#create-claim-property').change(function(){
-    initializeClaim($(':selected', this).data('type'));
+    initializeClaim();
   });
 
   function bindAddButton(){
@@ -144,7 +150,7 @@
   function createBasicClaim(pid, pidLabel, value, type) {
   // TODO: NEED LEVEL1 VALIDATION HERE
     var listTemplate = $(`
-      <li class="added-claim-li ${type}">
+      <li class="added-claim-li ${type}" data-pid="${pid}" data-value="${value}" data-type="${type}">
       <div class="row-div">
        <div class="added-property-div">
           ${pidLabel} <a class="wd-id" href="https://wikidata.org/wiki/Property:${pid}" target="_blank"> (${pid})</a></span>
@@ -159,6 +165,17 @@
     $('button#addClaimButton').remove();
     bindAddButton();
   }
+  function serializeClaimList(){
+    var array = $('.added-claim-li').map(function(){
+    return {
+      pid: $(this).data('pid'),
+      type: $(this).data('type'),
+      value: $(this).data('value'),
+    }
+}).get()
+console.log(array)
+return array
+  }
 
   function createItemClaim(pid, pidLabel, item, type) {
     // TODO: NEED LEVEL1 VALIDATION HERE
@@ -167,7 +184,7 @@
       description = 'this item has no description';
     }
     var listTemplate = $(`
-      <li class="added-claim-li ${type}">
+      <li class="added-claim-li ${type}" data-pid="${pid}" data-value="${item.id}" data-type="${type}">
       <div class="row-div">
         <div class="added-property-div">
           ${pidLabel} <a class="wd-id" href="https://wikidata.org/wiki/Property:${pid}" target="_blank"> (${pid})</a></span>
@@ -255,14 +272,37 @@
     }
     switch(type){
       case 'item':
-        validateItem(pid, select.val(), 'Q'+value, type)
+        validateItem(pid,
+        select.text().trim(), 'Q'+value, type)
         break;
       default:
         // TO DO: HAVE A CASE FOR EX-IDS AND URL'S
         console.log('form validated');
-        createBasicClaim(pid, select.val(), value, type);
+        createBasicClaim(pid,
+        select.text().trim(), value, type);
         break;
     }
+    return $('#saveClaimsLi').show()
+  }
+  function save_claims(){
+    var data = serializeClaimList()
+    console.log('STR->', JSON.stringify(data))
+    $.ajax({
+      type: 'POST',
+      url: "/api/{{selected['label'][0]}}/claims/write",
+      dataType: 'json',
+      contentType: 'application/json; charset=utf-8',
+      data: JSON.stringify(data),
+      success: function(response){
+        console.log(response)
+      },
+      error: function(error){
+        console.log(error)
+      }
+
+    })
+
+
   }
 
   $("input#lookup-input").keyup(function(event){

--- a/wikidp/templates/contribute.html
+++ b/wikidp/templates/contribute.html
@@ -1,355 +1,274 @@
-{% extends "page.html" %}
-{% block title %}Contribute {% endblock %}
-{% block page_content %}
-<script src="{{ url_for('static',filename='js/clipboard.min.js') }}"></script>
-<div id="panel-frame" class="contribute-page"  data-qid="{{selected['label'][0]}}">
-
-		<div id="sidebar-frame">
-			<div id="sidebar-div">
-				<!-- selected item -->
-				<div class="selected-item-div">
-					<div class="sidebar-header">selected item</div>
-					<select id="option-select" value="">
-					{% for option in options %}
-					{% if option[0] != selected['label'][0] %}
-
-					<option class="item-option" data-qid="{{option[0]}}"  data-label="{{option[1]}}" data-description="{{option[2]}}" title="{{option[2]}}" value="{{option[0]}}">
-						{{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
-					</option>
-					{% else %}
-					<option class="item-option" data-qid="{{option[0]}}"  data-label="{{option[1]}}" data-description="{{option[2]}}" title="{{option[2]}}" value="{{option[0]}}" selected="true">
-						{{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
-					</option>
-					{% endif %}
-					{% endfor %}
-					</select>
-				</div>
-
-				<!-- property overview -->
-				<div class="property-overview-div">
-					<div class="sidebar-header">property checklist</div>
-          <div id="sidebar-property-scroller">
-  					<ul id="sidebar-property-list" value="">
-  						{% for property in selected['properties'] %}
-  							{% if property[2] == 0%}
-  								<li class="sidebar-property-li">
-                    <span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
-      data-content-end=  ""></span>: 0
-
-  								</li>
-  							{% else %}
-  								<li class="sidebar-property-li property-ok">
-  									<span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
-      data-content-end=  ""></span>: {{property[2]}}
-  								</li>
-  							{% endif %}
-  						{% endfor %}
-  					</ul>
-          </div>
-				</div>
-
-				<!-- action buttons-->
-				<div class="actions-div">
-					<div class="sidebar-header">actions</div>
-					<ul id="sidebar-action-list" value="">
-						<li class="sidebar-action-li" id="explore-action">
-							explore
-						</li>
-						<li class="sidebar-action-li" id="preview-action">
-							preview
-						</li>
-						<li class="sidebar-action-li contribute-on" id="contribute-action">
-							contribute
-						</li>
-					</ul>
-				</div>
-
-			</div>
-		</div>
-
-
-
-		<div id="content-frame">
-
-		  <div id="header-text">
-        <span id="preview-item-name">{{selected['label'][1]}}<a class="wd-id" href="https://wikidata.org/wiki/{{selected['label'][0]}}" target="_blank"> ({{selected['label'][0]}})</a></span>
-        <br>
-        {% if selected['description'] != []%}
-        <span id="preview-item-description" title="{{selected['description']}}">{{selected['description']}}</span>
-        {% endif %}
-      </div>
-      <div id="statement-creation-frame">
-        <div id="creation-panel">
-          <div id="creation-div">
-            <span class="creation-section-header">CREATE A CLAIM</span><br>
-            <span class="creation-section-subtitle">Select a property below and we will provide you with a pre-formatted textbox.</span><br>
-              <div id="creation-content-div"><div id="creation-property-div">
-              <select id="create-claim-property">
-                <option class="default" data-type="default" >select a property</option>
-                {% for property in selected['properties'] %}
-                  <option class="" data-pid="{{property[0]}}" data-count="{{property[2]}}" data-type="{{property[3]}}">
-                    {{property[1]}}
-                  </option>
-              {% endfor %}
-              </select> :</div>
-              <div id="create-claim-value-div"> </div>
-            </div>
-          </div>
-          <div id="claims-list">
-            <span class="creation-section-header">MY CLAIMS</span><br>
-            <ul id="added-claims">
-
-            </ul>
-
-          </div>
-
+{% extends "item.html" %}
+{% block item_content %}
+  <script src="{{ url_for('static',filename='js/clipboard.min.js') }}"></script>
+  <div id="header-text">
+    <span id="preview-item-name">{{selected['label'][1]}}<a class="wd-id" href="https://wikidata.org/wiki/{{selected['label'][0]}}" target="_blank"> ({{selected['label'][0]}})</a></span>
+    <br>
+    {% if selected['description'] != []%}
+      <span id="preview-item-description" title="{{selected['description']}}">{{selected['description']}}</span>
+    {% endif %}
+  </div>
+  <div id="statement-creation-frame">
+    <div id="creation-panel">
+      <div id="creation-div">
+        <span class="creation-section-header">CREATE A CLAIM</span><br>
+        <span class="creation-section-subtitle">Select a property below and we will provide you with a pre-formatted textbox.</span><br>
+          <div id="creation-content-div"><div id="creation-property-div">
+          <select id="create-claim-property">
+            <option class="default" data-type="default" >select a property</option>
+            {% for property in selected['properties'] %}
+              <option class="" data-pid="{{property[0]}}" data-count="{{property[2]}}" data-type="{{property[3]}}">
+                {{property[1]}}
+              </option>
+            {% endfor %}
+          </select> :</div>
+          <div id="create-claim-value-div"> </div>
         </div>
-        <div class="" id="lookup-panel">
-          <div id="lookup-header-div">
-            looking for an item id?<br>
-             <input id="lookup-input" type=" " name="" placeholder="search here">
-          </div>
-          <div id="lookup-results-div">
-            <ul id="lookup-results-list">
-
-            </ul>
-          </div>
-        </div>
-
-
       </div>
-		</div>
-
-</div>
-
-<script type="text/javascript">
-function pageTransition(form){
-  $('div.page-container').fadeOut(500, function(){
-    $('body').append(form);
-    form.submit();
-  })
-}
-
-function initializeClaim(type){
-  $('select#create-claim-property option.default').prop('disabled', true)
-  console.log('...initialing data-type: '+type);
-  var div = $('div#create-claim-value-div').fadeOut(400, function(){
-    div.empty();
-    switch(type){
-      case 'string':
-          console.log('STRING');
-          div.append($('<input/>').attr({'placeholder':'enter value here', 'id':'claim-value'}));
-          bindAddButton();
-          break;
-      case 'ex-id':
-          console.log('EXID');
-          div.append($('<input/>').attr({'placeholder':'enter value here', 'id':'claim-value'}));
-          bindAddButton();
-          break;
-      case 'item':
-          console.log('ITEM');
-          div.append('Q',$('<input/>').attr({'placeholder':'1234', 'id':'claim-value', 'type':'number'}));
-          bindAddButton();
-          break;
-      case 'url':
-          console.log('URL');
-          div.append('https://',$('<input/>').attr({'placeholder':'www.website.com/', 'id':'claim-value', 'type':'url'}))
-          bindAddButton();
-          break;
-      default:
-          console.log('NONE OF THE ABOVE');
-          break;
-    }
-    div.fadeIn('slow');
-  });
-}
-
-$('select#option-select').change(function(){
-	var list = $('option.item-option')
-	var options = []
-	for (i = 0; i < list.length; i++){
-		// console.log($(list[i]).data('qid'), $(list[i]).data('label'));
-		options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
-	}
-	options = JSON.stringify(options);
-	console.log(options);
-	console.log($(this).val());
-  var form = $('<form action="/preview" method="post">' +
-    '<input type="text" name="qid" value="' + $(this).val() + '" />' +
-    '<input type="text" name="optionList" '+"value='"+options+"' />" +
-    '</form>');
-  $('body').append(form);
-  pageTransition(form);
-	// return $.post("/preview", {qid:qid})
-});
-
-$('li#preview-action').click(function(){
-  var list = $('option.item-option')
-  var options = []
-  for (i = 0; i < list.length; i++){
-    // console.log($(list[i]).data('qid'), $(list[i]).data('label'))
-    options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
-  }
-  options = JSON.stringify(options);
-  // console.log(options);
-  // console.log($('div#panel-frame').data('qid'));
-  var form = $('<form action="/preview" method="post">' +
-    '<input type="text" name="qid" value="' + $('div#panel-frame').data('qid') + '" />' +
-    '<input type="text" name="optionList" '+"value='"+options+"' />" +
-    '</form>').hide(0);
-  pageTransition(form);
-
-})
-
-$('select#create-claim-property').change(function(){
-  initializeClaim($(':selected', this).data('type'));
-});
-
-function bindAddButton(){
-  $('div#create-claim-value-div').append(' ',
-    $('<button/>').attr({'id':'addClaimButton', 'class':'off'}).prop("disabled",true).html('add claim')
-  );
-  $('input#claim-value').on('input', function(event){
-    if($('button#addClaimButton.on').length == 0){
-      $('button#addClaimButton.off').addClass('on').removeClass('off').prop("disabled",false).attr({'onclick':'claimFormValidation()'});
-    }
-    // TO DO: Let the user submit by enter, below this code does not perform quite as expected
-    // else if(event.keyCode == 13){
-    //   $('button#addClaimButton').click()
-    //  $('button#addClaimButton').click().prop("disabled", true)
-    // }
-  });
-}
-
-function createBasicClaim(pid, pidLabel, value, type) {
-// TODO: NEED LEVEL1 VALIDATION HERE
-  var listTemplate = $(`
-    <li class="added-claim-li ${type}">
-    <div class="row-div">
-     <div class="added-property-div">
-        ${pidLabel} <a class="wd-id" href="https://wikidata.org/wiki/Property:${pid}" target="_blank"> (${pid})</a></span>
-     </div>
-     <div class="added-value-div">
-          ${value}
-     </div></div>
-    </li>`).hide(0)
-  $('ul#added-claims').prepend(listTemplate);
-  $('ul#added-claims').scrollTop(0);
-  listTemplate.slideDown(750);
-  $('button#addClaimButton').remove();
-  bindAddButton();
-}
-
-function createItemClaim(pid, pidLabel, item, type) {
-  // TODO: NEED LEVEL1 VALIDATION HERE
-  var description = item.description
-  if (!description.length){
-    description = 'this item has no description';
-  }
-  var listTemplate = $(`
-    <li class="added-claim-li ${type}">
-    <div class="row-div">
-      <div class="added-property-div">
-        ${pidLabel} <a class="wd-id" href="https://wikidata.org/wiki/Property:${pid}" target="_blank"> (${pid})</a></span>
-     </div>
-     <div class="added-value-div">
-          <span class="added-label">${item.label} <a class="wd-id" href="https://wikidata.org/wiki/${item.id}" target="_blank">(${item.id})</a></span><br>
-          <i> &mdash; ${description} &mdash; </i></br>
-          <span class="sub-aka"><b>Also Referred To As:</b> ${item.aliases}</span>
-          </div>
-     </div></div>
-    </li>`).hide(0)
-  $('ul#added-claims').scrollTop(0);
-  $('ul#added-claims').prepend(listTemplate);
-  listTemplate.slideDown(750);
-  $('button#addClaimButton').remove();
-  bindAddButton();
-}
-
-function validateItem(pid, pidLabel, qid, type){
-  $.post("/api-get-qid-label", {qid:qid}, function(response){
-    response = JSON.parse(response);
-    console.log(response);
-    createItemClaim(pid, pidLabel, response, type);
-  }).fail(function(error){
-    console.log(error);
-  })
-}
-
-function lookupItem(string){
-  var list = $('ul#lookup-results-list').hide(1000);
-  $.post("/api-lookup-item", {string:string}, function(response){
-    response = JSON.parse(response)
-    console.log(response)
-    list.empty()
-    for (var opt = 0; opt < response.length; opt++){
-      var item = response[opt]
-      var qid = item.id
-      var description = item.description
-      if (!description.length){
-        description = 'this item has no description'
-      }
-      list.append(`
-        <li class="lookup-result-li">
-          <div class="result-main" id="result-main-${qid}" data-qid="${qid}">
-            <button data-clipboard-text="${qid}" class="pull-left clipboardBtn" id="clipboardBtn-${qid}" data-qid="${qid}"><i class="fa fa-clipboard"></i> </button>
-            <span class="result-label">${item.label}</span></br>
-            ${qid} <span class="glyphicon glyphicon-menu-down"></span>
-          </div>
-          <div class="result-sub" id="result-sub-${qid}">
-         <i> &mdash; ${description} &mdash; </i></br></br>
-          <span class="sub-aka"><b>Also Referred To As:</b> ${item.aliases}</span>
-          </div>
-        </li>
-        `);
-      var btn = document.getElementById('clipboardBtn-'+qid);
-      // Thanks to https://clipboardjs.com/ for this object below
-      var clipboard = new Clipboard(btn);
-      clipboard.on('success', function(e) {
-        console.log(e);
-      });
-      clipboard.on('error', function(e) {
-        console.log(e);
-      });
-    }
-    $('div.result-main').click(function(){
-      var id = $(this).data('qid');
-      console.log('calling--> ', id);
-      $('div#result-sub-'+id).slideToggle('slow');
+      <div id="claims-list">
+        <span class="creation-section-header">MY CLAIMS</span><br>
+        <ul id="added-claims">
+        </ul>
+      </div>
+    </div>
+    <div class="" id="lookup-panel">
+      <div id="lookup-header-div">
+        looking for an item id?<br>
+         <input id="lookup-input" type=" " name="" placeholder="search here">
+      </div>
+      <div id="lookup-results-div">
+        <ul id="lookup-results-list">
+        </ul>
+      </div>
+    </div>
+  </div>
+  <script type="text/javascript">
+  function pageTransition(form){
+    $('div#content-frame').fadeOut(500, function(){
+      $('body').append(form);
+      form.submit();
     })
-    list.fadeIn(1000);
-    // createItemClaim(pid, pidLabel, response, type)
-  }).fail(function(error){
-    console.log(error)
-  })
-}
-
-function claimFormValidation(){
-  var select = $(':selected', $('select#create-claim-property'))
-  var type = select.data('type')
-  var input = $('input#claim-value')
-  var pid = select.data('pid')
-  var value = input.val()
-  if (value.length == 0){
-    return console.log('no content')
   }
-  switch(type){
-    case 'item':
-      validateItem(pid, select.val(), 'Q'+value, type)
-      break;
-    default:
-      // TO DO: HAVE A CASE FOR EX-IDS AND URL'S
-      console.log('form validated');
-      createBasicClaim(pid, select.val(), value, type);
-      break;
-  }
-}
 
-$("input#lookup-input").keyup(function(event){
-    if(event.keyCode == 13){
-      lookupItem(this.value)
+  function initializeClaim(type){
+    $('select#create-claim-property option.default').prop('disabled', true)
+    console.log('...initialing data-type: '+type);
+    var div = $('div#create-claim-value-div').fadeOut(400, function(){
+      div.empty();
+      switch(type){
+        case 'string':
+            console.log('STRING');
+            div.append($('<input/>').attr({'placeholder':'enter value here', 'id':'claim-value'}));
+            bindAddButton();
+            break;
+        case 'ex-id':
+            console.log('EXID');
+            div.append($('<input/>').attr({'placeholder':'enter value here', 'id':'claim-value'}));
+            bindAddButton();
+            break;
+        case 'item':
+            console.log('ITEM');
+            div.append('Q',$('<input/>').attr({'placeholder':'1234', 'id':'claim-value', 'type':'number'}));
+            bindAddButton();
+            break;
+        case 'url':
+            console.log('URL');
+            div.append('https://',$('<input/>').attr({'placeholder':'www.website.com/', 'id':'claim-value', 'type':'url'}))
+            bindAddButton();
+            break;
+        default:
+            console.log('NONE OF THE ABOVE');
+            break;
+      }
+      div.fadeIn('slow');
+    });
+  }
+
+  $('select#option-select').change(function(){
+    var list = $('option.item-option')
+    var options = []
+    for (i = 0; i < list.length; i++){
+      // console.log($(list[i]).data('qid'), $(list[i]).data('label'));
+      options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
     }
-});
+    options = JSON.stringify(options);
+    console.log(options);
+    console.log($(this).val());
+    var form = $('<form action="/preview" method="post">' +
+      '<input type="text" name="qid" value="' + $(this).val() + '" />' +
+      '<input type="text" name="optionList" '+"value='"+options+"' />" +
+      '</form>');
+    $('body').append(form);
+    pageTransition(form);
+    // return $.post("/preview", {qid:qid})
+  });
 
-</script>
-    {% endblock page_content %}
+  $('li#preview-action').click(function(){
+    var list = $('option.item-option')
+    var options = []
+    for (i = 0; i < list.length; i++){
+      // console.log($(list[i]).data('qid'), $(list[i]).data('label'))
+      options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
+    }
+    options = JSON.stringify(options);
+    // console.log(options);
+    // console.log($('div#panel-frame').data('qid'));
+    var form = $('<form action="/preview" method="post">' +
+      '<input type="text" name="qid" value="' + $('div#panel-frame').data('qid') + '" />' +
+      '<input type="text" name="optionList" '+"value='"+options+"' />" +
+      '</form>').hide(0);
+    pageTransition(form);
+
+  })
+
+  $('select#create-claim-property').change(function(){
+    initializeClaim($(':selected', this).data('type'));
+  });
+
+  function bindAddButton(){
+    $('div#create-claim-value-div').append(' ',
+      $('<button/>').attr({'id':'addClaimButton', 'class':'off'}).prop("disabled",true).html('add claim')
+    );
+    $('input#claim-value').on('input', function(event){
+      if($('button#addClaimButton.on').length == 0){
+        $('button#addClaimButton.off').addClass('on').removeClass('off').prop("disabled",false).attr({'onclick':'claimFormValidation()'});
+      }
+      // TO DO: Let the user submit by enter, below this code does not perform quite as expected
+      // else if(event.keyCode == 13){
+      //   $('button#addClaimButton').click()
+      //  $('button#addClaimButton').click().prop("disabled", true)
+      // }
+    });
+  }
+
+  function createBasicClaim(pid, pidLabel, value, type) {
+  // TODO: NEED LEVEL1 VALIDATION HERE
+    var listTemplate = $(`
+      <li class="added-claim-li ${type}">
+      <div class="row-div">
+       <div class="added-property-div">
+          ${pidLabel} <a class="wd-id" href="https://wikidata.org/wiki/Property:${pid}" target="_blank"> (${pid})</a></span>
+       </div>
+       <div class="added-value-div">
+            ${value}
+       </div></div>
+      </li>`).hide(0)
+    $('ul#added-claims').prepend(listTemplate);
+    $('ul#added-claims').scrollTop(0);
+    listTemplate.slideDown(750);
+    $('button#addClaimButton').remove();
+    bindAddButton();
+  }
+
+  function createItemClaim(pid, pidLabel, item, type) {
+    // TODO: NEED LEVEL1 VALIDATION HERE
+    var description = item.description
+    if (!description.length){
+      description = 'this item has no description';
+    }
+    var listTemplate = $(`
+      <li class="added-claim-li ${type}">
+      <div class="row-div">
+        <div class="added-property-div">
+          ${pidLabel} <a class="wd-id" href="https://wikidata.org/wiki/Property:${pid}" target="_blank"> (${pid})</a></span>
+       </div>
+       <div class="added-value-div">
+            <span class="added-label">${item.label} <a class="wd-id" href="https://wikidata.org/wiki/${item.id}" target="_blank">(${item.id})</a></span><br>
+            <i> &mdash; ${description} &mdash; </i></br>
+            <span class="sub-aka"><b>Also Referred To As:</b> ${item.aliases}</span>
+            </div>
+       </div></div>
+      </li>`).hide(0)
+    $('ul#added-claims').scrollTop(0);
+    $('ul#added-claims').prepend(listTemplate);
+    listTemplate.slideDown(750);
+    $('button#addClaimButton').remove();
+    bindAddButton();
+  }
+
+  function validateItem(pid, pidLabel, qid, type){
+    $.post("/api-get-qid-label", {qid:qid}, function(response){
+      response = JSON.parse(response);
+      console.log(response);
+      createItemClaim(pid, pidLabel, response, type);
+    }).fail(function(error){
+      console.log(error);
+    })
+  }
+
+  function lookupItem(string){
+    var list = $('ul#lookup-results-list').hide(1000);
+    $.post("/api-lookup-item", {string:string}, function(response){
+      response = JSON.parse(response)
+      console.log(response)
+      list.empty()
+      for (var opt = 0; opt < response.length; opt++){
+        var item = response[opt]
+        var qid = item.id
+        var description = item.description
+        if (!description.length){
+          description = 'this item has no description'
+        }
+        list.append(`
+          <li class="lookup-result-li">
+            <div class="result-main" id="result-main-${qid}" data-qid="${qid}">
+              <button data-clipboard-text="${qid}" class="pull-left clipboardBtn" id="clipboardBtn-${qid}" data-qid="${qid}"><i class="fa fa-clipboard"></i> </button>
+              <span class="result-label">${item.label}</span></br>
+              ${qid} <span class="glyphicon glyphicon-menu-down"></span>
+            </div>
+            <div class="result-sub" id="result-sub-${qid}">
+           <i> &mdash; ${description} &mdash; </i></br></br>
+            <span class="sub-aka"><b>Also Referred To As:</b> ${item.aliases}</span>
+            </div>
+          </li>
+          `);
+        var btn = document.getElementById('clipboardBtn-'+qid);
+        // Thanks to https://clipboardjs.com/ for this object below
+        var clipboard = new Clipboard(btn);
+        clipboard.on('success', function(e) {
+          console.log(e);
+        });
+        clipboard.on('error', function(e) {
+          console.log(e);
+        });
+      }
+      $('div.result-main').click(function(){
+        var id = $(this).data('qid');
+        console.log('calling--> ', id);
+        $('div#result-sub-'+id).slideToggle('slow');
+      })
+      list.fadeIn(1000);
+      // createItemClaim(pid, pidLabel, response, type)
+    }).fail(function(error){
+      console.log(error)
+    })
+  }
+
+  function claimFormValidation(){
+    var select = $(':selected', $('select#create-claim-property'))
+    var type = select.data('type')
+    var input = $('input#claim-value')
+    var pid = select.data('pid')
+    var value = input.val()
+    if (value.length == 0){
+      return console.log('no content')
+    }
+    switch(type){
+      case 'item':
+        validateItem(pid, select.val(), 'Q'+value, type)
+        break;
+      default:
+        // TO DO: HAVE A CASE FOR EX-IDS AND URL'S
+        console.log('form validated');
+        createBasicClaim(pid, select.val(), value, type);
+        break;
+    }
+  }
+
+  $("input#lookup-input").keyup(function(event){
+      if(event.keyCode == 13){
+        lookupItem(this.value)
+      }
+  });
+  </script>
+{% endblock item_content %}

--- a/wikidp/templates/item.html
+++ b/wikidp/templates/item.html
@@ -1,0 +1,13 @@
+{% extends "page.html" %}
+{% block title %}{{page}} {% endblock %}
+{% block page_content %}
+<div id="panel-frame" class="{{page}}-page" data-qid="{{selected['label'][0]}}">
+  <div id="sidebar-frame">
+		{% include "sidebar.html" %}
+  </div>
+  <div id="content-frame">
+    {% block item_content %}
+    {% endblock item_content %}
+  </div>
+</div>
+{% endblock page_content %}

--- a/wikidp/templates/preview-item.html
+++ b/wikidp/templates/preview-item.html
@@ -1,299 +1,221 @@
-{% extends "page.html" %}
-{% block title %}Preview {% endblock %}
-{% block page_content %}
-<div id="panel-frame" data-qid="{{selected['label'][0]}}">
-
-		<div id="sidebar-frame">
-			<div id="sidebar-div">
-				<!-- selected item -->
-				<div class="selected-item-div">
-					<div class="sidebar-header">selected item</div>
-					<select id="option-select" value="">
-					{% for option in options %}
-					{% if option[0] != selected['label'][0] %}
-
-					<option class="item-option" data-qid="{{option[0]}}"  data-label="{{option[1]}}" data-description="{{option[2]}}" title="{{option[2]}}" value="{{option[0]}}">
-						{{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
-					</option>
-					{% else %}
-					<option class="item-option" data-qid="{{option[0]}}"  data-label="{{option[1]}}" data-description="{{option[2]}}" title="{{option[2]}}" value="{{option[0]}}" selected="true">
-						{{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
-					</option>
-					{% endif %}
-					{% endfor %}
-					</select>
-				</div>
-
-				<!-- property overview -->
-				<div class="property-overview-div">
-					<div class="sidebar-header">property checklist</div>
-					<div id="sidebar-property-scroller" class="scroller">
-					<ul id="sidebar-property-list" value="">
-						{% for property in selected['properties'] %}
-  							{% if property[2] == 0%}
-  								<li class="sidebar-property-li">
-                    <span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
-      data-content-end=  ""></span>: 0
-
-  								</li>
-  							{% else %}
-  								<li class="sidebar-property-li property-ok">
-  									<span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
-      data-content-end=  ""></span>: {{property[2]}}
-  								</li>
-  							{% endif %}
-  						{% endfor %}
-					</ul></div>
-				</div>
-
-				<!-- action buttons-->
-				<div class="actions-div">
-					<div class="sidebar-header">actions</div>
-					<ul id="sidebar-action-list" value="">
-						<li class="sidebar-action-li" id="explore-action">
-							explore
-						</li>
-						<li class="sidebar-action-li preview-on" id="preview-action">
-							preview
-						</li>
-						<li class="sidebar-action-li" id="contribute-action" onclick="">
-							contribute
-						</li>
-					</ul>
-				</div>
-
-			</div>
+{% extends "item.html" %}
+{% block item_content %}
+<!-- preview page specific -->
+	<div id="preview-div">
+	<div id="header-text">
+		<span id="preview-item-name"><span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{selected['label'][0]}}">{{selected['label'][1]}}</span><a class="wd-id" href="https://wikidata.org/wiki/{{selected['label'][0]}}" target="_blank"> ({{selected['label'][0]}})</a></span>
+		<br>
+		{% if selected['description'] != []%}
+		<span id="preview-item-description" title="{{selected['description']}}">{{selected['description']}}</span>
+		{% endif %}
+		<div id="languageSelectDiv">
+			Language:
+			<select name="" id="languageSelect">
+				<option value="en">English</option>
+				<option value="fr">French</option>
+				<option value="es">Spanish</option>
+			</select>
 		</div>
+	</div>
+		<div id="claims-div">
+		<div class="table-header-div">
+			<span class="tbl-cat">
+					Current Data About <span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{selected['label'][0]}}">{{selected['label'][1]}}</span>
+				</span></div>
+				<div id="claims-scroller" class="scroller">
 
+					<table  class="table claims-table table-responsive table-striped table-hover">
 
+				{% for clm in selected['claims']%}
+					<tr>
+						<td class="invert-col">
+							{{ clm[1] }}
+							<a target="_blank" href="https://wikidata.org/wiki/property:{{clm[0]}}" class="">
+								({{clm[0]}})
+							</a>
+						</td>
+						<td>
+							{% for sub in selected['claims'][clm] %}
+								<span class="detail-row">
+									{% if clm[2] == 2 %}
+										{% if sub[0][0] == 'Q' %}
+											<span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{sub[0]}}">{{sub[1]}}</span>
+											<a href="/{{sub[0]}}" class="p_or_q_id">
+												({{ sub[0] }})
+											</a>
+										{% elif sub[0][0] == 'P' %}
+											{{ sub[1] }}
+											<a target="_blank" href="https://wikidata.org/wiki/property:{{sub[0]}}" class="">
+												({{sub[0]}})
+											</a>
+										{% endif %}
+									{% elif clm[2] == 1%}
+										{% if clm[0] == 'P18' or clm[0] == 'P154' %}
+											<a target="_blank" href="{{sub}}">
+												<img class="property-image" src="{{sub}}" style="border:0;" width="80%">
+											</a>
+										{% else %}
+											{{ sub }}
+										{% endif %}
+									{%endif%}
+									{% if (clm[0],sub[0]) in selected['refs'] %}
+										<table class="reference-table  table-responsive table-striped table-hover">
+											{%for x in selected['refs'][(clm[0],sub[0])] %}
+												<tr>
+													<td>
+														{{ x[1] }}
+														<a target="_blank" href="https://wikidata.org/wiki/property:{{x[0]}}" class="">
+															({{ x[0] }})
+														</a>
+													</td>
+													<td>
+														{% if x[2] is string %}
+															{{x[2]}}
+														{% else %}
+																{% if x[2][0][0] == 'Q' %}
+																	<a target="_blank" href="https://wikidata.org/wiki/{{x[2][0]}}"class="">
+																		<span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{x[2][0]}}">{{x[2][1]}}</span>
+																	</a>
+																{% else %}
+																	<a target="_blank" href="https://wikidata.org/wiki/property:{{x[2][0]}}"class="">
+																		{{x[2][0]}}
+																	</a>
+																{% endif %}
 
-		<div id="content-frame">
-
-		<!-- preview page specific -->
-			<div id="preview-div">
-			<div id="header-text">
-				<span id="preview-item-name"><span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{selected['label'][0]}}">{{selected['label'][1]}}</span><a class="wd-id" href="https://wikidata.org/wiki/{{selected['label'][0]}}" target="_blank"> ({{selected['label'][0]}})</a></span>
-				<br>
-				{% if selected['description'] != []%}
-        <span id="preview-item-description" title="{{selected['description']}}">{{selected['description']}}</span>
-        {% endif %}
-				<div id="languageSelectDiv">
-					Language:
-					<select name="" id="languageSelect">
-						<option value="en">English</option>
-						<option value="fr">French</option>
-						<option value="es">Spanish</option>
-					</select>
-				</div>
-			</div>
-				<div id="claims-div">
-				<div class="table-header-div">
-					<span class="tbl-cat">
-              Current Data About <span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{selected['label'][0]}}">{{selected['label'][1]}}</span>
-            </span></div>
-            <div id="claims-scroller" class="scroller">
-
-							<table  class="table claims-table table-responsive table-striped table-hover">
-
-            {% for clm in selected['claims']%}
-              <tr>
-                <td class="invert-col">
-                  {{ clm[1] }}
-                  <a target="_blank" href="https://wikidata.org/wiki/property:{{clm[0]}}" class="">
-                    ({{clm[0]}})
-                  </a>
-                </td>
-                <td>
-                  {% for sub in selected['claims'][clm] %}
-                    <span class="detail-row">
-                      {% if clm[2] == 2 %}
-                        {% if sub[0][0] == 'Q' %}
-                          <span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{sub[0]}}">{{sub[1]}}</span>
-                          <a href="/{{sub[0]}}" class="p_or_q_id">
-                            ({{ sub[0] }})
-                          </a>
-                        {% elif sub[0][0] == 'P' %}
-                          {{ sub[1] }}
-                          <a target="_blank" href="https://wikidata.org/wiki/property:{{sub[0]}}" class="">
-                            ({{sub[0]}})
-                          </a>
-                        {% endif %}
-                      {% elif clm[2] == 1%}
-                        {% if clm[0] == 'P18' or clm[0] == 'P154' %}
-                          <a target="_blank" href="{{sub}}">
-                            <img class="property-image" src="{{sub}}" style="border:0;" width="80%">
-                          </a>
-                        {% else %}
-                          {{ sub }}
-                        {% endif %}
-                      {%endif%}
-                      {% if (clm[0],sub[0]) in selected['refs'] %}
-                        <table class="reference-table  table-responsive table-striped table-hover">
-                          {%for x in selected['refs'][(clm[0],sub[0])] %}
-                            <tr>
-                              <td>
-                                {{ x[1] }}
-                                <a target="_blank" href="https://wikidata.org/wiki/property:{{x[0]}}" class="">
-                                  ({{ x[0] }})
-                                </a>
-                              </td>
-                              <td>
-                                {% if x[2] is string %}
-                                  {{x[2]}}
-                                {% else %}
-                                    {% if x[2][0][0] == 'Q' %}
-                                      <a target="_blank" href="https://wikidata.org/wiki/{{x[2][0]}}"class="">
-		                                    <span class="qlabel" its-ta-ident-ref="http://www.wikidata.org/entity/{{x[2][0]}}">{{x[2][1]}}</span>
-		                                  </a>
-                                    {% else %}
-                                      <a target="_blank" href="https://wikidata.org/wiki/property:{{x[2][0]}}"class="">
-		                                    {{x[2][0]}}
-		                                  </a>
-                                    {% endif %}
-
-                                {% endif %}
-                              </td>
-                            </tr>
-                          {% endfor %}
-                        </table>
-                      {%endif%}
-                      </br>
-                    </span>
-                  {% endfor %}
-                </td>
-              </tr>
-            {% endfor %}
-          </table>
+														{% endif %}
+													</td>
+												</tr>
+											{% endfor %}
+										</table>
+									{%endif%}
+									</br>
+								</span>
+							{% endfor %}
+						</td>
+					</tr>
+				{% endfor %}
+			</table>
 
 
 </div>
 
-				</div>
-				<div id="other-info-div">
-				<div class="table-header-div">
-				<span class="tbl-cat">
-            other details
-          </span></div>
-          <div id="other-info-scroller" class="scroller">
-          <table class="selected-table table-responsive table-striped table-hover">
-            {%if selected['aliases'] != []%}
-              <tr>
-                <td>
-                  Aliases
-                </td>
-                <td>
-                  {%for p in selected['aliases']%}
-                    {{p}}
-                  {%endfor%}
-                </td>
-              </tr>
-            {%endif%}
-            {%if selected['description'] != []%}
-              <tr>
-                <td>
-                  Description
-                </td>
-                <td id="sub_description">
-                  {{selected['description']}}
-                </td>
-              </tr>
-            {%endif%}
-          </table>
-          {%if selected['ex-ids'] != []%}
-          <br>
-
-					<span class="tbl-cat">External Links </span>
-          <table class="ex-links-table  table-responsive table-striped table-hover">
-            {%for p in selected['ex-ids']%}
-              <tr>
-                <td>
-                  {{p[1]}}
-                  <a target="_blank" href="https://wikidata.org/wiki/property:{{p[0]}}" class="">
-                    ({{ p[0] }})
-                  </a>
-                </td>
-                <td>
-                  {%if p[3] != 'unavailable'%}
-                    <a target="_blank" href="{{p[3]}}">
-                      {{p[2]}}
-                    </a>
-                  {%else%}
-                    {{p[2]}}
-                  {%endif%}
-                </td>
-              </tr>
-            {%endfor%}
-          </table>
-          {%endif%}
-          </div>
-
-				</div>
-			</div>
-		<!-- end preview page specific -->
 		</div>
+		<div id="other-info-div">
+		<div class="table-header-div">
+		<span class="tbl-cat">
+				other details
+			</span></div>
+			<div id="other-info-scroller" class="scroller">
+			<table class="selected-table table-responsive table-striped table-hover">
+				{%if selected['aliases'] != []%}
+					<tr>
+						<td>
+							Aliases
+						</td>
+						<td>
+							{%for p in selected['aliases']%}
+								{{p}}
+							{%endfor%}
+						</td>
+					</tr>
+				{%endif%}
+				{%if selected['description'] != []%}
+					<tr>
+						<td>
+							Description
+						</td>
+						<td id="sub_description">
+							{{selected['description']}}
+						</td>
+					</tr>
+				{%endif%}
+			</table>
+			{%if selected['ex-ids'] != []%}
+			<br>
 
+			<span class="tbl-cat">External Links </span>
+			<table class="ex-links-table  table-responsive table-striped table-hover">
+				{%for p in selected['ex-ids']%}
+					<tr>
+						<td>
+							{{p[1]}}
+							<a target="_blank" href="https://wikidata.org/wiki/property:{{p[0]}}" class="">
+								({{ p[0] }})
+							</a>
+						</td>
+						<td>
+							{%if p[3] != 'unavailable'%}
+								<a target="_blank" href="{{p[3]}}">
+									{{p[2]}}
+								</a>
+							{%else%}
+								{{p[2]}}
+							{%endif%}
+						</td>
+					</tr>
+				{%endfor%}
+			</table>
+			{%endif%}
+			</div>
 
-</table>
-
-<script type="text/javascript">
-var LANG = 'en';
-	$(document).ready(function(){
-		$('img.property-image').fadeIn(4000)
+		</div>
+	</div>
+	<script type="text/javascript">
+	var LANG = 'en';
+		$(document).ready(function(){
+			$('img.property-image').fadeIn(4000)
+		})
+		function pageTransition(form){
+	  $('div#content-frame').fadeOut(500, function(
+	  ){
+	  $('body').append(form);
+	form.submit();
 	})
-	function pageTransition(form){
-  $('div.page-container').fadeOut(500, function(
-  ){
-  $('body').append(form);
-form.submit();
-})
-}
-	$('select#option-select').change(function(){
-		var list = $('option.item-option')
-		var options = []
-		for (i = 0; i < list.length; i++){
-		console.log($(list[i]).data('qid'), $(list[i]).data('label'))
-			options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
-		}
-		options = JSON.stringify(options)
-		console.log(options)
-		console.log($(this).val())
+	}
+		$('select#option-select').change(function(){
+			var list = $('option.item-option')
+			var options = []
+			for (i = 0; i < list.length; i++){
+			console.log($(list[i]).data('qid'), $(list[i]).data('label'))
+				options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
+			}
+			options = JSON.stringify(options)
+			console.log(options)
+			console.log($(this).val())
 
-var form = $('<form action="/preview" method="post">' +
-  '<input type="text" name="qid" value="' + $(this).val() + '" />' +
-  '<input type="text" name="optionList" '+"value='"+options+"' />" +
-  '</form>').hide(0);
-pageTransition(form)
-		// return $.post("/preview", {qid:qid})
-	});
+	var form = $('<form action="/preview" method="post">' +
+	  '<input type="text" name="qid" value="' + $(this).val() + '" />' +
+	  '<input type="text" name="optionList" '+"value='"+options+"' />" +
+	  '</form>').hide(0);
+	pageTransition(form)
+			// return $.post("/preview", {qid:qid})
+		});
 
-	$('li#contribute-action').click(function(){
-		var list = $('option.item-option')
-		var options = []
-		for (i = 0; i < list.length; i++){
-		console.log($(list[i]).data('qid'), $(list[i]).data('label'))
-			options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
-		}
-		options = JSON.stringify(options)
-		console.log(options)
-		console.log($('div#panel-frame').data('qid'))
+		$('li#contribute-action').click(function(){
+			var list = $('option.item-option')
+			var options = []
+			for (i = 0; i < list.length; i++){
+			console.log($(list[i]).data('qid'), $(list[i]).data('label'))
+				options.push([$(list[i]).data('qid').replace("'","&#39;"), $(list[i]).data('label').replace("'","&#39;"), $(list[i]).data('description').replace("'","&#39;") ])
+			}
+			options = JSON.stringify(options)
+			console.log(options)
+			console.log($('div#panel-frame').data('qid'))
 
-var form = $('<form action="/contribute" method="post">' +
-  '<input type="text" name="qid" value="' + $('div#panel-frame').data('qid') + '" />' +
-  '<input type="text" name="optionList" '+"value='"+options+"' />" +
-  '</form>').hide(0);
-pageTransition(form)
-	})
-	$('.scroller').scroll(function()
-	{
+	var form = $('<form action="/contribute" method="post">' +
+	  '<input type="text" name="qid" value="' + $('div#panel-frame').data('qid') + '" />' +
+	  '<input type="text" name="optionList" '+"value='"+options+"' />" +
+	  '</form>').hide(0);
+	pageTransition(form)
+		})
+		$('.scroller').scroll(function()
+		{
+				$.qLabel.switchLanguage(LANG);
+		});
+		$('#languageSelect').change(function(){
+			LANG = $('#languageSelect').val()
 			$.qLabel.switchLanguage(LANG);
-	});
-	$('#languageSelect').change(function(){
-		LANG = $('#languageSelect').val()
-		$.qLabel.switchLanguage(LANG);
-	})
-</script>
-
-
-
-
-    {% endblock page_content %}
+		})
+	</script>
+<!-- end preview page specific -->
+  {% endblock item_content %}

--- a/wikidp/templates/sidebar.html
+++ b/wikidp/templates/sidebar.html
@@ -1,0 +1,56 @@
+<div id="sidebar-div">
+  <!-- action buttons-->
+  <div class="actions-div">
+    <ul id="sidebar-action-list" value="">
+      <li class="sidebar-action-li" id="explore-action">
+        explore
+      </li>
+      <li class="sidebar-action-li {% if page == 'preview' %}preview-on{% endif %}" id="preview-action">
+        preview
+      </li>
+      <li class="sidebar-action-li {% if page == 'contribute' %}contribute-on{% endif %}" id="contribute-action" onclick="">
+        contribute
+      </li>
+    </ul>
+  </div>
+  <!-- selected item -->
+  <div class="selected-item-div">
+    <div class="sidebar-header">selected item</div>
+    <select id="option-select" value="">
+    {% for option in options %}
+    {% if option[0] != selected['label'][0] %}
+
+    <option class="item-option" data-qid="{{option[0]}}"  data-label="{{option[1]}}" data-description="{{option[2]}}" title="{{option[2]}}" value="{{option[0]}}">
+      {{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
+    </option>
+    {% else %}
+    <option class="item-option" data-qid="{{option[0]}}"  data-label="{{option[1]}}" data-description="{{option[2]}}" title="{{option[2]}}" value="{{option[0]}}" selected="true">
+      {{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
+    </option>
+    {% endif %}
+    {% endfor %}
+    </select>
+  </div>
+
+  <!-- property overview -->
+  <div class="property-overview-div">
+    <div class="sidebar-header">property checklist</div>
+    <div id="sidebar-property-scroller" class="scroller">
+    <ul id="sidebar-property-list" value="">
+      {% for property in selected['properties'] %}
+          {% if property[2] == 0%}
+            <li class="sidebar-property-li">
+              <span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
+data-content-end=  ""></span>: 0
+
+            </li>
+          {% else %}
+            <li class="sidebar-property-li property-ok">
+              <span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
+data-content-end=  ""></span>: {{property[2]}}
+            </li>
+          {% endif %}
+        {% endfor %}
+    </ul></div>
+  </div>
+</div>

--- a/wikidp/templates/sidebar.html
+++ b/wikidp/templates/sidebar.html
@@ -39,15 +39,15 @@
     <ul id="sidebar-property-list" value="">
       {% for property in selected['properties'] %}
           {% if property[2] == 0%}
-            <li class="sidebar-property-li">
+            <li class="sidebar-property-li" data-pid="{{property[0]}}">
               <span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
-data-content-end=  ""></span>: 0
+data-content-end=  ""></span> <div class="sidebar-property-count">: 0</div>
 
             </li>
           {% else %}
-            <li class="sidebar-property-li property-ok">
+            <li class="sidebar-property-li property-ok" data-pid="{{property[0]}}">
               <span title="{{property[1]}} ({{property[0]}})" data-content-start="{{property[1]}} ({{property[0]}}) "
-data-content-end=  ""></span>: {{property[2]}}
+data-content-end=  ""></span> <div class="sidebar-property-count">: {{property[2]}} </div>
             </li>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
This feature change adds the ability for a user to commit ("Save") to test wikidata. For now, all writes will point to the same item (https://test.wikidata.org/wiki/Q175461) because there is no overlap between production wikidata and test.wikidata (even down to properties). Also, the functionality is currently limited to claims that follow the pattern _(item property item)_ meaning all values must be another test.wikidata item or the write will be deemed unsuccessful. I have a todo task to extend this to the other value datatypes (strings, urls, datetime, ex-ids, etc)

Issues Addressed:
fixed #52 in c3d54e3