### PR TITLE
MAINT: Updated Ansible roll out tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,34 @@ this creates an _htmlcov/index.html_ file for browser viewing
 (venv) $ ./coverage_report.sh visual
 ````
 
+# Ansible roll out
 
+## Local vagrant VM
+`vagrant up`
+
+## Install Ansible roles locally
+```bash
+ansible-galaxy install -r ansible/requirements.yml
+```
+
+### Ansible CLI roll out to local Vagrant VM
+```bash
+ansible-playbook --key-file=.vagrant/machines/default/virtualbox/private_key -v --inventory ansible/vagrant vagrant.yml
+```
+
+### First time setup for any server via SSH, needs root password for server
+```bash
+ansible-playbook ansible/setup.yml -i ansible/staging.yml -u root -vv -k
+```
+
+https://unix.stackexchange.com/questions/332641/how-to-install-python-3-6
+wget https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz
+tar xvf Python-3.6.3.tgz
+cd Python-3.6.3
+./configure --enable-optimizations
+make -j8
+sudo make altinstall
+python3.6
 
 
 Troubleshooting

--- a/ansible/production
+++ b/ansible/production
@@ -1,0 +1,7 @@
+# Define all servers children
+[servers:children]
+wikidp
+
+# The child list of WikiDP servers
+[wikidp]
+production

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,1 @@
-- src: tschifftner.hostname
-- src: tersmitten.timezone
-  version: v1.0.11
-- src: tersmitten.apt
-  version: v1.4.7
 - src: nginxinc.nginx

--- a/ansible/roles/wikidp.portal/defaults/main.yml
+++ b/ansible/roles/wikidp.portal/defaults/main.yml
@@ -7,7 +7,7 @@ wikidp_user: "{{ wikidp_app_name }}"
 wikidp_group: "{{ wikidp_user }}"
 wikidp_user_home: "/home/{{ wikidp_user }}"
 wikidp_app_home: "{{ wikidp_user_home }}/{{ wikidp_app_name }}"
-wikidp_host: "{{ hostname }}"
+wikidp_host: "{{ opf_server_hostname }}"
 
 wikidp_git_remote: "https://github.com/WikiDP/portal-proto.git"
 wikidp_git_local: "{{ wikidp_app_home }}/src"

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -2,6 +2,30 @@
 # Playbook to configure a Vagrant box WikiDP Portal instance
 # File: ansible/vagrant.yml
 
+- name: Store known hosts of 'all' the hosts in the inventory file
+  hosts: localhost
+  connection: local
+
+  vars:
+    ssh_known_hosts_command: "ssh-keyscan -T 10"
+    ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
+    ssh_known_hosts: "{{ groups['all'] }}"
+
+  tasks:
+
+  - name: For each host, scan for its ssh public key
+    shell: "ssh-keyscan {{ item }},`dig +short {{ item }}`"
+    with_items: "{{ ssh_known_hosts }}"
+    register: ssh_known_host_results
+    ignore_errors: yes
+
+  - name: Add/update the public key in the '{{ ssh_known_hosts_file }}'
+    known_hosts:
+      name: "{{ item.item }}"
+      key: "{{ item.stdout }}"
+      path: "{{ ssh_known_hosts_file }}"
+    with_items: "{{ ssh_known_host_results.results }}"
+
 - hosts: all
   gather_facts: no
   pre_tasks:
@@ -11,12 +35,6 @@
 - hosts: all
   become: true
   roles:
-    - { role: tschifftner.hostname }
-    - { role: tersmitten.timezone }
-    - { role: tersmitten.apt }
-
-- hosts: vagrant
-  become: true
-  roles:
+    - { role: opf.server }
     - { role: wikidp.portal }
     - { role: wikidp.wikibase }


### PR DESCRIPTION
- added basic ansible instructions to `README.md`;
- removed unused ansible requirements;
- fixed default vars for used with `opf.server` role;
- playbooks now use OPF server tasks; and
- production ansible server hierarchy.