### PR TITLE
REFACT: War on Pylint errors

### DIFF
--- a/wikidp/__init__.py
+++ b/wikidp/__init__.py
@@ -15,8 +15,9 @@
 import logging
 
 from wikidp.config import APP
-from wikidp import routes
-
+from . import (
+    routes,
+)
 if __name__ == "__main__":
     logging.debug("Importing %s", routes.__name__)
     logging.debug("Running Flask App on Port %s", APP.config.get('PORT'))

--- a/wikidp/config.py
+++ b/wikidp/config.py
@@ -23,7 +23,7 @@ from .const import ConfKey
 HOST = 'localhost'
 TEMP = tempfile.gettempdir()
 
-
+# pylint: disable=R0903
 class BaseConfig():
     """Base / default config, no debug logging and short log format."""
     HOST = HOST
@@ -39,19 +39,17 @@ class BaseConfig():
     ITEM_REGEX = r'(Q|q)\d+'
     PROPERTY_REGEX = r'(P|p)\d+'
 
-
+# pylint: disable=R0903
 class DevConfig(BaseConfig):
     """Developer level config, with debug logging and long log format."""
     DEBUG = True
     LOG_FORMAT = '[%(asctime)s %(levelname)-8s %(filename)-15s:%(lineno)-5d ' +\
                  '%(funcName)-30s] %(message)s'
 
-
 CONFIGS = {
     "dev": 'wikidp.config.DevConfig',
     "default": 'wikidp.config.BaseConfig'
 }
-
 
 def configure_app(app):
     """Grabs the environment variable for app config or defaults to dev."""

--- a/wikidp/config.py
+++ b/wikidp/config.py
@@ -26,6 +26,7 @@ TEMP = tempfile.gettempdir()
 # pylint: disable=R0903
 class BaseConfig():
     """Base / default config, no debug logging and short log format."""
+
     HOST = HOST
     DEBUG = False
     LOG_FORMAT = '[%(filename)-15s:%(lineno)-5d] %(message)s'
@@ -42,6 +43,7 @@ class BaseConfig():
 # pylint: disable=R0903
 class DevConfig(BaseConfig):
     """Developer level config, with debug logging and long log format."""
+
     DEBUG = True
     LOG_FORMAT = '[%(asctime)s %(levelname)-8s %(filename)-15s:%(lineno)-5d ' +\
                  '%(funcName)-30s] %(message)s'
@@ -52,7 +54,7 @@ CONFIGS = {
 }
 
 def configure_app(app):
-    """Grabs the environment variable for app config or defaults to dev."""
+    """Grab the environment variable for app config or defaults to dev."""
     config_name = os.getenv('WIKIDP_CONFIG', 'dev')
     app.config.from_object(CONFIGS[config_name])
     app.config['STATIC_DIR'] = os.path.join(app.root_path, 'static')

--- a/wikidp/const.py
+++ b/wikidp/const.py
@@ -10,6 +10,7 @@
 # about the terms of this license.
 #
 """Constants used across BitCurator modules.
+
 These need to map to the names used in the default config file, but better
 than multiple hardcoded strings in code.
 """
@@ -41,7 +42,8 @@ DEFAULT_UI_LANGUAGES = [
 
 # pylint: disable=R0903
 class ConfKey():
-    """Config key string constants"""
+    """Config key string constants."""
+
     LOG_FORMAT = 'LOG_FORMAT'
     LOG_FILE = 'LOG_FILE'
     WIKIDATA_LANG = 'WIKIDATA_LANG'

--- a/wikidp/const.py
+++ b/wikidp/const.py
@@ -39,7 +39,7 @@ DEFAULT_UI_LANGUAGES = [
     ("lb", "Lëtzebuergesch (Luxembourgish)")
 ]
 
-
+# pylint: disable=R0903
 class ConfKey():
     """Config key string constants"""
     LOG_FORMAT = 'LOG_FORMAT'

--- a/wikidp/controllers/__init__.py
+++ b/wikidp/controllers/__init__.py
@@ -1,0 +1,1 @@
+"""Module for application logic controllers."""

--- a/wikidp/controllers/api.py
+++ b/wikidp/controllers/api.py
@@ -9,7 +9,7 @@
 # License, Version 3. See the text file "COPYING" for further details
 # about the terms of this license.
 #
-""" Flask application routes for Wikidata portal. """
+"""Flask application routes for Wikidata portal."""
 import logging
 
 from flask import (
@@ -33,7 +33,7 @@ SCHEMA_DIRECTORY_PATH = 'wikidp/schemas/'
 
 
 def load_schema(schema_name):
-    """ Load a schema file by name. """
+    """Load a schema file by name."""
     try:
         with open(SCHEMA_DIRECTORY_PATH+schema_name) as data_file:
             return json.load(data_file)
@@ -42,7 +42,7 @@ def load_schema(schema_name):
 
 
 def get_schema_properties(schema_name):
-    """ Get all of the properties of a particular schema, """
+    """Get all of the properties of a particular schema."""
     data = load_schema(schema_name)
     if data is False:
         return False
@@ -65,7 +65,7 @@ def get_schema_properties(schema_name):
 
 
 def get_property_checklist_from_schema(schema_name):
-    """ Create a property checklist from a schema. """
+    """Create a property checklist from a schema."""
     pid_list = get_schema_properties(schema_name)
     if pid_list:
         return get_property_details_by_pid_list(pid_list)
@@ -73,7 +73,7 @@ def get_property_checklist_from_schema(schema_name):
 
 
 def write_claims_to_item(qid):
-    """ Writing new claims to an item. """
+    """Writing new claims to an item."""
     logging.debug("Processing user POST request.")
     user_claims = request.get_json()
     successful_claims = []
@@ -98,7 +98,7 @@ def write_claims_to_item(qid):
 
 
 def get_target_by_type(value_type, value):
-    """ Return the correct target by value_type. """
+    """Return the correct target by value_type."""
     if value_type == 'WikibaseItem':
         return pywikibot.ItemPage(REPO, value)
     # elif data_type == 'Coordinate'
@@ -107,17 +107,19 @@ def get_target_by_type(value_type, value):
 
 # pylint: disable=R0913
 def write_claim(item, prop_string, value, data_type, qualifiers, meta=False):
-    """Write a claim to WikiData.
-    TODO: Use wikidataintegrator2 here and account for qualifiers and references
+    """
+    Write a claim to WikiData.
+
+    TODO: Use wikidataintegrator2 here and account for qualifiers and references.
     Args:
-        item (pywikibot.ItemPage): Wikidata Item Model
-        prop_string (str): Wikidata Property Identifier [ex. 'P1234']
-        value (str): Value matching accepted property
-        data_type: (could be other data types)
-        qualifiers (list): list of data about qualifier claims
-        meta (dict, optional): Contains information about qualifiers/references/summaries
+        item (pywikibot.ItemPage): Wikidata Item Model.
+        prop_string (str): Wikidata Property Identifier [ex. 'P1234'].
+        value (str): Value matching accepted property.
+        data_type: (could be other data types).
+        qualifiers (list): list of data about qualifier claims.
+        meta (dict, optional): Contains information about qualifiers/references/summaries.
     Returns:
-        bool: True if successful, False otherwise
+        bool: True if successful, False otherwise.
     """
     try:
         claim = pywikibot.Claim(REPO, prop_string)

--- a/wikidp/controllers/api.py
+++ b/wikidp/controllers/api.py
@@ -105,6 +105,7 @@ def get_target_by_type(value_type, value):
     return value
 
 
+# pylint: disable=R0913
 def write_claim(item, prop_string, value, data_type, qualifiers, meta=False):
     """Write a claim to WikiData.
     TODO: Use wikidataintegrator2 here and account for qualifiers and references

--- a/wikidp/controllers/api.py
+++ b/wikidp/controllers/api.py
@@ -13,13 +13,12 @@
 import logging
 
 from flask import (
-     json,
-     jsonify,
-     request,
+    json,
+    jsonify,
+    request,
 )
 import pywikibot
 
-from wikidp.models import FileFormat
 from wikidp.utils import (
     get_pid_from_string,
     get_property_details_by_pid_list,
@@ -34,14 +33,16 @@ SCHEMA_DIRECTORY_PATH = 'wikidp/schemas/'
 
 
 def load_schema(schema_name):
+    """ Load a schema file by name. """
     try:
         with open(SCHEMA_DIRECTORY_PATH+schema_name) as data_file:
             return json.load(data_file)
-    except (Exception, FileNotFoundError):
+    except FileNotFoundError:
         return False
 
 
 def get_schema_properties(schema_name):
+    """ Get all of the properties of a particular schema, """
     data = load_schema(schema_name)
     if data is False:
         return False
@@ -64,6 +65,7 @@ def get_schema_properties(schema_name):
 
 
 def get_property_checklist_from_schema(schema_name):
+    """ Create a property checklist from a schema. """
     pid_list = get_schema_properties(schema_name)
     if pid_list:
         return get_property_details_by_pid_list(pid_list)
@@ -71,6 +73,7 @@ def get_property_checklist_from_schema(schema_name):
 
 
 def write_claims_to_item(qid):
+    """ Writing new claims to an item. """
     logging.debug("Processing user POST request.")
     user_claims = request.get_json()
     successful_claims = []
@@ -95,6 +98,7 @@ def write_claims_to_item(qid):
 
 
 def get_target_by_type(value_type, value):
+    """ Return the correct target by value_type. """
     if value_type == 'WikibaseItem':
         return pywikibot.ItemPage(REPO, value)
     # elif data_type == 'Coordinate'
@@ -115,7 +119,6 @@ def write_claim(item, prop_string, value, data_type, qualifiers, meta=False):
         bool: True if successful, False otherwise
     """
     try:
-        # TODO: Account for all dataTypes
         claim = pywikibot.Claim(REPO, prop_string)
         target = get_target_by_type(data_type, value)
         claim.setTarget(target)
@@ -127,14 +130,8 @@ def write_claim(item, prop_string, value, data_type, qualifiers, meta=False):
             claim.addQualifier(qualifier, summary=u'Adding a qualifier.')
 
         if meta:
-            # TODO: Add Ability to include references, summaries, and qualifiers
             pass
         item.addClaim(claim, summary=u'Adding claim')
         return True
-    except (TypeError, Exception):
+    except TypeError:
         return False
-
-
-def get_all_file_formats():
-    formats = FileFormat.list_formats()
-    return formats

--- a/wikidp/controllers/pages.py
+++ b/wikidp/controllers/pages.py
@@ -1,3 +1,17 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
+""" Module for WikiDP pages. """
 from flask import (
     json,
     request,
@@ -14,6 +28,7 @@ SCHEMA_DIRECTORY_PATH = 'wikidp/schemas/'
 
 
 def get_item_context(qid, with_claims=True):
+    """ Retrieve an item by QID with accompaying claims if requested. """
     selected_item = item_detail_parse(qid, with_claims=with_claims)
     options = None
     schemas = None
@@ -28,6 +43,7 @@ def get_item_context(qid, with_claims=True):
 
 
 def get_checklist_context(qid, schema):
+    """ Create a property checklist from a schema. """
     checklist = get_property_checklist_from_schema(schema)
     if checklist:
         counts = get_item_property_counts(qid)
@@ -43,4 +59,5 @@ def get_checklist_context(qid, schema):
 
 
 def get_schema_list():
+    """ Get a flat list of schema files. """
     return get_directory_filenames_with_subdirectories(SCHEMA_DIRECTORY_PATH)

--- a/wikidp/controllers/pages.py
+++ b/wikidp/controllers/pages.py
@@ -11,7 +11,7 @@
 #
 # This is a python __init__ script to create the app and import the
 # main package contents
-""" Module for WikiDP pages. """
+"""Module for WikiDP pages."""
 from flask import (
     json,
     request,
@@ -28,7 +28,7 @@ SCHEMA_DIRECTORY_PATH = 'wikidp/schemas/'
 
 
 def get_item_context(qid, with_claims=True):
-    """ Retrieve an item by QID with accompaying claims if requested. """
+    """Retrieve an item by QID with accompaying claims if requested."""
     selected_item = item_detail_parse(qid, with_claims=with_claims)
     options = None
     schemas = None
@@ -43,7 +43,7 @@ def get_item_context(qid, with_claims=True):
 
 
 def get_checklist_context(qid, schema):
-    """ Create a property checklist from a schema. """
+    """Create a property checklist from a schema."""
     checklist = get_property_checklist_from_schema(schema)
     if checklist:
         counts = get_item_property_counts(qid)
@@ -59,5 +59,5 @@ def get_checklist_context(qid, schema):
 
 
 def get_schema_list():
-    """ Get a flat list of schema files. """
+    """Get a flat list of schema files."""
     return get_directory_filenames_with_subdirectories(SCHEMA_DIRECTORY_PATH)

--- a/wikidp/controllers/search.py
+++ b/wikidp/controllers/search.py
@@ -32,6 +32,7 @@ from wikidp.utils import (
 def get_search_result_context(search_string):
     """
     Get search results from a substring.
+
     Args:
         search_string (str):
 
@@ -58,9 +59,10 @@ def get_search_result_context(search_string):
 
 def search_result_list(string):
     """
-    Use wikidataintegrator to generate a list of similar items based on a
-    text search and returns a list of (qid, Label, description, aliases)
-    dictionaries
+    Use wikidataintegrator to generate a list of similar items.
+
+    This is based on a text search and returns a list of
+    (qid, Label, description, aliases) dictionaries.
     """
     result_qid_list = WDItemEngine.get_wd_search_results(string, language=LANG)
     output = []
@@ -72,7 +74,7 @@ def search_result_list(string):
 
 
 def get_search_by_puid_context(puid):
-    """ Perform an item search by PUID. """
+    """Perform an item search by PUID."""
     new_puid = puid.replace('_', '/')
     logging.debug("Searching for PUID: %s", new_puid)
     results = PuidSearchResult.search_puid(new_puid, lang=LANG)

--- a/wikidp/controllers/search.py
+++ b/wikidp/controllers/search.py
@@ -1,3 +1,16 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
 """Search Controller Functions and Helpers for WikiDP."""
 
 import logging
@@ -31,6 +44,7 @@ def get_search_result_context(search_string):
         for res in FileFormatExtSearchResult.search(search_string)
     ]
     # Check if searching with PUID
+    # pylint: disable=W1401
     if re.search("[x-]?fmt/\d+", search_string) is not None:
         context.extend([
             {'qid': res.format, 'label': res.label,
@@ -58,6 +72,7 @@ def search_result_list(string):
 
 
 def get_search_by_puid_context(puid):
+    """ Perform an item search by PUID. """
     new_puid = puid.replace('_', '/')
     logging.debug("Searching for PUID: %s", new_puid)
     results = PuidSearchResult.search_puid(new_puid, lang=LANG)

--- a/wikidp/models.py
+++ b/wikidp/models.py
@@ -75,6 +75,7 @@ class FileFormat():
 
 class PuidSearchResult():
     """Encapsulates a file format plus wikidata query magic for formats."""
+    # pylint: disable=R0913
     def __init__(self, wd_format, label, description, mime, puid):
         self._format = wd_format
         self._label = label
@@ -162,11 +163,11 @@ class FileFormatExtSearchResult(PuidSearchResult):
     def _build_query(search_string="", lang="en"):
         query = """
         SELECT DISTINCT ?format ?formatLabel ?formatDescription ?extension
-        WHERE {  
+        WHERE {
             ?format wdt:P1195 ?extension.
-            FILTER(CONTAINS(?extension, '<value>' ))  
-            SERVICE wikibase:label { 
-                bd:serviceParam wikibase:language "[AUTO_LANGUAGE],<lang>". 
+            FILTER(CONTAINS(?extension, '<value>' ))
+            SERVICE wikibase:label {
+                bd:serviceParam wikibase:language "[AUTO_LANGUAGE],<lang>".
             }
         }
         """

--- a/wikidp/models.py
+++ b/wikidp/models.py
@@ -19,7 +19,9 @@ from wikidp.const import LANG
 
 class FileFormat():
     """Encapsulates a file format plus wikidata query magic for formats."""
+
     def __init__(self, qid, name, media_types=None):
+        """Constructor for a FileFormat instance."""
         self._qid = qid
         self._name = name
         self._media_types = media_types if media_types else []
@@ -40,6 +42,7 @@ class FileFormat():
         return self._media_types
 
     def __str__(self):
+        """Return a string reprsentation of the format instance."""
         _media_types = '|'.join(self.media_types)
         return "FileFormat : [qid={}, name={}, media_types=[{}]]".format(self.qid,
                                                                          self.name,
@@ -51,7 +54,7 @@ class FileFormat():
 
     @classmethod
     def list_formats(cls, lang=None):
-        """Queries Wikidata for formats and returns a list of FileFormat instances."""
+        """Query Wikidata for formats and returns a list of FileFormat instances."""
         if not lang:
             lang = LANG
         query = [
@@ -72,11 +75,12 @@ class FileFormat():
                    for x in results_json['results']['bindings']]
         return results
 
-
 class PuidSearchResult():
     """Encapsulates a file format plus wikidata query magic for formats."""
+
     # pylint: disable=R0913
     def __init__(self, wd_format, label, description, mime, puid):
+        """Constructor for a PUID search result instance."""
         self._format = wd_format
         self._label = label
         self._description = description
@@ -109,12 +113,13 @@ class PuidSearchResult():
         return self._puid
 
     def __str__(self):
+        """Return a string reprsentation of a PUID result."""
         return "PuidSearchResult : [format={}, label={}, MIME={}, puid={}]"\
             .format(self.format, self.label, self.mime, self.puid)
 
     @classmethod
     def search_puid(cls, puid, lang="en"):
-        """Queries Wikidata for formats and returns a list of FileFormat instances."""
+        """Query Wikidata for formats and returns a list of FileFormat instances."""
         query = cls._concat_query("VALUES ?puid {{ '{}' }}".format(puid), lang)
         results_json = wdi_core.WDItemEngine.execute_sparql_query(query)
         logging.debug(str(results_json))
@@ -122,7 +127,7 @@ class PuidSearchResult():
 
     @classmethod
     def search_mime(cls, mime, lang="en"):
-        """Queries Wikidata for formats and returns a list of FileFormat instances."""
+        """Query Wikidata for formats and returns a list of FileFormat instances."""
         query = cls._concat_query("VALUES ?mime {{ '{}' }}".format(mime), lang)
         results_json = wdi_core.WDItemEngine.execute_sparql_query(query)
         logging.debug(str(results_json))
@@ -154,8 +159,10 @@ class PuidSearchResult():
 
 
 class FileFormatExtSearchResult(PuidSearchResult):
-    """ File Format Extension Search Result Model. """
+    """File Format Extension Search Result Model."""
+
     def __init__(self, wd_id, label, description):
+        """Constructor for a File Format Extension search result instance."""
         super(FileFormatExtSearchResult, self).__init__(wd_id, label,
                                                         description, None, None)
 
@@ -188,6 +195,7 @@ class FileFormatExtSearchResult(PuidSearchResult):
     def search(cls, search_string, lang="en"):
         """
         Query Wikidata to get search results.
+
         Args:
             search_string (str):
             lang (str):

--- a/wikidp/routes/__init__.py
+++ b/wikidp/routes/__init__.py
@@ -1,3 +1,16 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
 """Package description file for routes."""
 from . import (
     _converters,

--- a/wikidp/routes/_converters.py
+++ b/wikidp/routes/_converters.py
@@ -12,7 +12,7 @@
 """ Flask application custom url converters for Wikidata portal. """
 from werkzeug.routing import BaseConverter
 
-from wikidp import APP
+from wikidp.config import APP
 from wikidp.const import (
     ITEM_REGEX,
     PROPERTY_REGEX,

--- a/wikidp/routes/_converters.py
+++ b/wikidp/routes/_converters.py
@@ -9,7 +9,7 @@
 # License, Version 3. See the text file "COPYING" for further details
 # about the terms of this license.
 #
-""" Flask application custom url converters for Wikidata portal. """
+"""Flask application custom url converters for Wikidata portal."""
 from werkzeug.routing import BaseConverter
 
 from wikidp.config import APP

--- a/wikidp/routes/_filters.py
+++ b/wikidp/routes/_filters.py
@@ -14,7 +14,7 @@ from urllib.parse import quote_plus
 
 from markupsafe import Markup
 
-from wikidp import APP
+from wikidp.config import APP
 from wikidp.const import ENTITY_URL_PATTERN
 from wikidp.utils import (
     get_pid_from_string,

--- a/wikidp/routes/_filters.py
+++ b/wikidp/routes/_filters.py
@@ -9,7 +9,7 @@
 # License, Version 3. See the text file "COPYING" for further details
 # about the terms of this license.
 #
-""" Flask application custom template filters for Wikidata portal. """
+"""Flask application custom template filters for Wikidata portal."""
 from urllib.parse import quote_plus
 
 from markupsafe import Markup
@@ -35,7 +35,8 @@ def template_filter_url_encode(to_encode):
 @APP.template_filter('qlabel_attributes')
 def template_qlabel_attributes(url):
     """
-    Add tag attributes for qlabel.js
+    Add tag attributes for qlabel.js.
+
     Args:
         url (str): Text for the label and titles
 
@@ -48,7 +49,8 @@ def template_qlabel_attributes(url):
 @APP.template_filter('entity_url')
 def template_filter_entity_url(entity_id):
     """
-    Convert Item of Property string to Wikidata URL
+    Convert Item of Property string to Wikidata URL.
+
     Args:
         entity_id (str): Item ('Q1234') or Property ('P1234') identifier
 

--- a/wikidp/routes/api.py
+++ b/wikidp/routes/api.py
@@ -30,61 +30,61 @@ from wikidp.utils import (
 
 @APP.route("/api/")
 def route_api_welcome():
-    """Landing Page API index"""
+    """Landing Page API index."""
     return 'Welcome to the WikiDP API'
 
 
 @APP.route("/api/<item:qid>", methods=['GET', 'POST'])
 def route_api_get_item(qid):
-    """User posts a item-id and returns json of (id, label, desc, aliases) ."""
+    """User posts a item-id and returns json of (id, label, desc, aliases)."""
     item = item_detail_parse(qid, with_claims=True)
     return jsonify(item)
 
 
 @APP.route("/api/<item:qid>/summary", methods=['GET', 'POST'])
 def route_api_get_item_summary(qid):
-    """User posts a item-id and returns json of (id, label, desc, aliases) ."""
+    """User posts a item-id and returns json of (id, label, desc, aliases)."""
     item = item_detail_parse(qid, with_claims=False)
     return jsonify(item)
 
 
 @APP.route("/api/<item:qid>/claims/write", methods=['POST'])
 def route_api_write_claims_to_item(qid):
-    """ User posts a JSON object of claims to contribute to an item"""
+    """User posts a JSON object of claims to contribute to an item."""
     return write_claims_to_item(qid)
 
 
 @APP.route("/api/<prop:pid>", methods=['GET', 'POST'])
 def route_api_get_property(pid):
-    """ Return a JSON representation of a property by ID. """
+    """Return a JSON representation of a property by ID."""
     prop = get_property(pid)
     return jsonify(prop)
 
 
 @APP.route("/api/<prop:pid>/qualifiers", methods=['GET', 'POST'])
 def route_api_get_allowed_qualifiers_by_pid(pid):
-    """ Return the legal qualifiers for the property identified by pid. """
+    """Return the legal qualifiers for the property identified by pid."""
     output = get_allowed_qualifiers_by_pid(pid)
     return jsonify(output)
 
 
 @APP.route("/api/property/qualifiers", methods=['GET', 'POST'])
 def route_api_get_all_qualifier_properties():
-    """ Return a JSON representation of all qualifier properties. """
+    """Return a JSON representation of all qualifier properties."""
     output = get_all_qualifier_properties()
     return jsonify(output)
 
 
 @APP.route("/api/language/", methods=['GET', 'POST'])
 def route_api_get_all_languages():
-    """ Return JSON representation of all supported languages. """
+    """Return JSON representation of all supported languages."""
     output = get_all_languages()
     return jsonify(output)
 
 
 @APP.route("/api/search/<search_string>", methods=['GET', 'POST'])
 def route_api_search_item_by_string(search_string):
-    """Post string, returns list of json of (id, label, desc, aliases) ."""
+    """Post string, returns list of json of (id, label, desc, aliases)."""
     _string = search_string.strip()
     output = search_result_list(_string)
     return jsonify(output)

--- a/wikidp/routes/api.py
+++ b/wikidp/routes/api.py
@@ -56,24 +56,28 @@ def route_api_write_claims_to_item(qid):
 
 @APP.route("/api/<prop:pid>", methods=['GET', 'POST'])
 def route_api_get_property(pid):
+    """ Return a JSON representation of a property by ID. """
     prop = get_property(pid)
     return jsonify(prop)
 
 
 @APP.route("/api/<prop:pid>/qualifiers", methods=['GET', 'POST'])
 def route_api_get_allowed_qualifiers_by_pid(pid):
+    """ Return the legal qualifiers for the property identified by pid. """
     output = get_allowed_qualifiers_by_pid(pid)
     return jsonify(output)
 
 
 @APP.route("/api/property/qualifiers", methods=['GET', 'POST'])
 def route_api_get_all_qualifier_properties():
+    """ Return a JSON representation of all qualifier properties. """
     output = get_all_qualifier_properties()
     return jsonify(output)
 
 
 @APP.route("/api/language/", methods=['GET', 'POST'])
 def route_api_get_all_languages():
+    """ Return JSON representation of all supported languages. """
     output = get_all_languages()
     return jsonify(output)
 
@@ -88,11 +92,13 @@ def route_api_search_item_by_string(search_string):
 
 @APP.route("/api/schema/<path:schema_name>/properties")
 def route_api_get_properties_by_schema(schema_name):
+    """ Return a JSON representation of all the properties from a particular schema. """
     prop_list = get_property_checklist_from_schema(schema_name)
     return jsonify(prop_list)
 
 
 @APP.route("/api/browse/file_format", methods=['GET', 'POST'])
 def route_api_browse_file_format():
+    """ Return a list of all file formats. """
     format_list = FileFormat.list_formats()
     return jsonify([x.api_dict() for x in format_list])

--- a/wikidp/routes/api.py
+++ b/wikidp/routes/api.py
@@ -14,11 +14,11 @@ from flask import jsonify
 
 from wikidp.config import APP
 from wikidp.controllers.api import (
-    get_all_file_formats,
     get_property_checklist_from_schema,
     write_claims_to_item,
 )
 from wikidp.controllers.search import search_result_list
+from wikidp.models import FileFormat
 from wikidp.utils import (
     get_all_languages,
     get_all_qualifier_properties,
@@ -94,5 +94,5 @@ def route_api_get_properties_by_schema(schema_name):
 
 @APP.route("/api/browse/file_format", methods=['GET', 'POST'])
 def route_api_browse_file_format():
-    format_list = get_all_file_formats()
+    format_list = FileFormat.list_formats()
     return jsonify([x.api_dict() for x in format_list])

--- a/wikidp/routes/forms.py
+++ b/wikidp/routes/forms.py
@@ -11,7 +11,7 @@
 #
 # This is a python __init__ script to create the app and import the
 # main package contents
-""" Module for application form routes. """
+"""Module for application form routes."""
 from flask import (
     redirect,
     request,
@@ -27,7 +27,7 @@ def route_form_preview_item():
 
 @APP.route("/contribute", methods=['POST'])
 def route_form_contribute_item():
-    """Processes contribute page into a state-saving url."""
+    """Process contribute page into a state-saving url."""
     qid = request.form['qid']
     return redirect('/{qid}/contribute?qid={qid}&options={opts}'. \
         format(qid=qid, opts=request.form['optionList']))

--- a/wikidp/routes/forms.py
+++ b/wikidp/routes/forms.py
@@ -1,3 +1,17 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
+""" Module for application form routes. """
 from flask import (
     redirect,
     request,
@@ -15,4 +29,5 @@ def route_form_preview_item():
 def route_form_contribute_item():
     """Processes contribute page into a state-saving url."""
     qid = request.form['qid']
-    return redirect('/{}/contribute?qid={}&options={}'.format(qid, qid, request.form['optionList']))
+    return redirect('/{qid}/contribute?qid={qid}&options={opts}'. \
+        format(qid=qid, opts=request.form['optionList']))

--- a/wikidp/routes/pages.py
+++ b/wikidp/routes/pages.py
@@ -1,4 +1,4 @@
-""" Python functions for all WikiDP page routes. """
+"""Python functions for all WikiDP page routes."""
 import logging
 import os
 
@@ -28,7 +28,7 @@ APP.register_blueprint(MWOAUTH.bp)
 
 @APP.route("/")
 def route_page_welcome():
-    """Landing Page for first time"""
+    """Landing Page for first time."""
     return render_template('welcome.html')
 
 @APP.route('/favicon.ico')
@@ -39,17 +39,17 @@ def route_favicon():
 
 @APP.route("/about")
 def route_page_about():
-    """Rendering the about page"""
+    """Render the about page."""
     return render_template('about.html')
 
 @APP.route("/reports")
 def route_page_reports():
-    """Rendering the reports page"""
+    """Render the reports page."""
     return render_template('reports.html')
 
 @APP.route("/profile")
 def profile():
-    """ Flask OAuth login. """
+    """Flask OAuth login."""
     logging.debug("getting user")
     username = MWOAUTH.get_current_user(True)
     identity = None
@@ -59,25 +59,25 @@ def profile():
 
 @APP.route("/unauthorized")
 def route_page_unauthorized():
-    """Displays a 403 error page."""
+    """Display a 403 error page."""
     return abort(403)
 
 
 @APP.route("/error")
 def route_page_error():
-    """Displays a 500 error page."""
+    """Display a 500 error page."""
     return abort(500)
 
 
 @APP.route("/<item:qid>")
 def route_page_selected_item(qid):
-    """If the item ID is already known, the user can enter in the url"""
+    """If the item ID is already known, the user can enter in the url."""
     return redirect('/'+qid+'/preview')
 
 
 @APP.route("/<item:qid>/preview")
 def route_item_preview(qid):
-    """If the item ID is already known, the user can enter in the url"""
+    """If the item ID is already known, the user can enter in the url."""
     selected_item, options, schemas = get_item_context(qid, with_claims=True)
     if selected_item:
         return render_template('item_preview.html', item=selected_item,
@@ -88,7 +88,7 @@ def route_item_preview(qid):
 
 @APP.route("/<item:qid>/contribute")
 def route_item_contribute(qid):
-    """Handles a user's contributed statements."""
+    """Handle a user's contributed statements."""
     selected_item, options, schemas = get_item_context(qid, with_claims=False)
     if selected_item:
         return render_template('item_contribute.html', item=selected_item,
@@ -99,27 +99,27 @@ def route_item_contribute(qid):
 
 @APP.route("/<item:qid>/checklist/<path:schema>")
 def route_item_checklist_by_schema(qid, schema):
-    """ Render property checklist for given item and schema. """
+    """Render property checklist for given item and schema."""
     properties = get_checklist_context(qid, schema)
     return render_template('snippets/property_checklist.html', properties=properties)
 
 @APP.errorhandler(400)
 @APP.errorhandler(404)
 def route_page_error__not_found(excep):
-    """ Handler for HTTP 400, Bad request and 404 not found. """
+    """Handler for HTTP 400, Bad request and 404 not found."""
     _log_error_message('Not Found: %s', excep)
     return render_template('error.html', message="Page Not Found"), 404
 
 @APP.errorhandler(403)
 def route_page_error__forbidden(excep):
-    """ Handler for HTTP 403, Forbidden. """
+    """Handler for HTTP 403, Forbidden."""
     _log_error_message('Forbidden: %s', excep)
     return render_template('error.html', message="You are not authorized to view this page."), 403
 
 @APP.errorhandler(500)
 @APP.errorhandler(Exception)
 def route_page_error__internal_error(excep):
-    """ Handler for HTTP 500, Internal Server Error. """
+    """Handler for HTTP 500, Internal Server Error."""
     _log_error_message('Internal Server Error: %s', excep)
     return render_template('error.html',
                            message="Internal Error. Please Help us by reporting"

--- a/wikidp/routes/search.py
+++ b/wikidp/routes/search.py
@@ -1,3 +1,17 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
+""" Module for WikiDP application search routes. """
 from flask import redirect, render_template, request
 from wikidp.config import APP
 from wikidp.controllers import search as search_controller

--- a/wikidp/routes/search.py
+++ b/wikidp/routes/search.py
@@ -11,7 +11,7 @@
 #
 # This is a python __init__ script to create the app and import the
 # main package contents
-""" Module for WikiDP application search routes. """
+"""Module for WikiDP application search routes."""
 from flask import redirect, render_template, request
 from wikidp.config import APP
 from wikidp.controllers import search as search_controller
@@ -19,15 +19,16 @@ from wikidp.controllers import search as search_controller
 
 @APP.route("/search", methods=['POST'])
 def route_process_site_search():
-    """Processes search request into a state-saving url."""
+    """Process a search request into a state-saving url."""
     return redirect('/search?string='+request.form['userInput'].strip())
 
 
 @APP.route("/search")
 def route_site_search():
     """
-    Displays the most likely results of a users search
-    if only one result returned, the user is automatic redirected to preview that item
+    Display the most likely results of a users search.
+
+    if only one result returned, the user is automatic redirected to preview that item.
     """
     search_string = request.args.get('string', default=0, type=str)
     context = search_controller.get_search_result_context(search_string)
@@ -38,6 +39,6 @@ def route_site_search():
 
 @APP.route("/search/puid/<string:puid>")
 def route_search_by_puid(puid):
-    """Displays a list of extensions and media types."""
+    """Display a list of extensions and media types."""
     new_puid, results = search_controller.get_search_by_puid_context(puid)
     return render_template('puid_results.html', results=results, puid=new_puid)

--- a/wikidp/sparql.py
+++ b/wikidp/sparql.py
@@ -12,8 +12,9 @@
 # This is a python __init__ script to create the app and import the
 # main package contents
 """
-Collection of sparql queries and related functions turned into python functions
-Note: Remove any comments from queries
+Collection of sparql queries and related functions turned into python functions.
+
+Note: Remove any comments from queries.
 """
 
 PROPERTY_QUERY = """

--- a/wikidp/sparql.py
+++ b/wikidp/sparql.py
@@ -1,10 +1,23 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
 """
 Collection of sparql queries and related functions turned into python functions
 Note: Remove any comments from queries
 """
 
 PROPERTY_QUERY = """
-    SELECT  (STRAFTER(STR(?property), 'entity/') as ?id) ?property ?propertyType ?propertyLabel 
+    SELECT  (STRAFTER(STR(?property), 'entity/') as ?id) ?property ?propertyType ?propertyLabel
     ?propertyDescription ?propertyAltLabel (STRAFTER(STR(?propertyType), '#') as ?value_type) ?formatter_url
     WHERE {
     VALUES (?property) { $values }
@@ -18,7 +31,7 @@ PROPERTY_QUERY = """
 """
 
 ALL_QUALIFIER_PROPERTIES = """
-    SELECT (STRAFTER(STR(?property), 'entity/') as ?id) ?property ?propertyType ?propertyLabel 
+    SELECT (STRAFTER(STR(?property), 'entity/') as ?id) ?property ?propertyType ?propertyLabel
     ?propertyDescription ?propertyAltLabel (STRAFTER(STR(?propertyType), '#') as ?value_type)
     WHERE {
       ?property wikibase:propertyType ?propertyType .
@@ -30,7 +43,7 @@ ALL_QUALIFIER_PROPERTIES = """
 
 PROPERTY_ALLOWED_QUALIFIERS = """
     SELECT (STRAFTER(STR(?property), 'entity/') as ?id) ?property ?propertyType ?propertyLabel  ?propertyAltLabel
-    (?propertyLabel as ?label) ?propertyDescription (?propertyDescription as ?description) 
+    (?propertyLabel as ?label) ?propertyDescription (?propertyDescription as ?description)
     (STRAFTER(STR(?propertyType), '#') as ?value_type)
     WHERE {
         VALUES (?main_property) { $values }

--- a/wikidp/utils/__init__.py
+++ b/wikidp/utils/__init__.py
@@ -1,5 +1,17 @@
-""" General purpose utitlites for wikidp. """
-
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
+"""Package description file for utils and general purpose WikiDP utilities."""
 from collections import namedtuple
 from datetime import datetime
 import json
@@ -14,11 +26,7 @@ import re
 from string import Template
 from urllib import request as urllib_request
 
-from six import text_type
-from six.moves.urllib.parse import parse_qs
 import validators
-
-from wikidataintegrator.wdi_core import WDItemEngine
 
 from wikidp.const import (
     ITEM_REGEX,
@@ -33,10 +41,9 @@ from wikidp.sparql import (
     PROPERTY_QUERY,
 )
 
-RequestToken = namedtuple("RequestToken", ['key', 'secret'])
-
-class OAuthException(Exception):
-    pass
+from . import (
+    wd_int_utils,
+)
 
 def dedupe_by_key(dict_list, key):
     """
@@ -59,33 +66,33 @@ def dedupe_by_key(dict_list, key):
     return output
 
 
-def flatten_string(_string):
+def _flatten_string(_string):
     return " ".join(_string.split())
 
 
-def file_to_label(filename):
-    output = remove_extension_from_filename(filename)
+def _file_to_label(filename):
+    output = _remove_extension_from_filename(filename)
     return output.replace('_', ' ').title()
 
 
 def get_pid_from_string(input_string):
+    """ Parse and return a property id from a string value. """
     regex_search = re.search(PROPERTY_REGEX, input_string)
     return regex_search.group() if regex_search else False
 
 
 def get_qid_from_string(input_string):
+    """ Parse and return an item id from a string value. """
     regex_search = re.search(ITEM_REGEX, input_string)
     return regex_search.group() if regex_search else False
 
-
-def entity_id_to_int(entity):
+def _entity_id_to_int(entity):
     return int(entity[1:])
 
-
 def get_property(pid):
+    """ Return the first value from a list of properties. """
     prop_response = get_property_details_by_pid_list([pid])
     return prop_response[0] if prop_response else None
-
 
 def convert_list_to_value_string(lst):
     """
@@ -93,17 +100,6 @@ def convert_list_to_value_string(lst):
         Returns: "(wd:P31)(wd:P5)(wd:P123)"
     """
     return '(wd:{0})'.format(')(wd:'.join(map(str, lst)))
-
-
-def format_wikidata_bindings(bindings):
-    return [{k: v.get('value') for k, v in res.items()} for res in bindings]
-
-
-def process_query_string(query):
-    result = WDItemEngine.execute_sparql_query(query)
-    bindings = result['results'].get('bindings')
-    return format_wikidata_bindings(bindings)
-
 
 def get_all_languages():
     """
@@ -125,31 +121,33 @@ def get_all_languages():
         ]
 
     """
-    query = flatten_string(ALL_LANGUAGES_QUERY)
-    return process_query_string(query)
+    query = _flatten_string(ALL_LANGUAGES_QUERY)
+    return wd_int_utils.process_query_string(query)
 
 
 def get_all_qualifier_properties():
-    query = flatten_string(ALL_QUALIFIER_PROPERTIES)
-    return process_query_string(query)
+    """ Return all of the qualifiers for a particular property. """
+    query = _flatten_string(ALL_QUALIFIER_PROPERTIES)
+    return wd_int_utils.process_query_string(query)
 
 
 def get_allowed_qualifiers_by_pid(pid):
+    """ Return all legal quailifiers for a partiular property. """
     value = convert_list_to_value_string([pid])
     query = PROPERTY_ALLOWED_QUALIFIERS_TEMPLATE.substitute(values=value)
-    return process_query_string(query)
-
+    return wd_int_utils.process_query_string(query)
 
 def get_property_details_by_pid_list(pid_list):
+    """ Return property details from a property id list. """
     values = convert_list_to_value_string(pid_list)
     query = PROPERTY_QUERY_TEMPLATE.substitute(values=values)
-    return process_query_string(query)
-
+    return wd_int_utils.process_query_string(query)
 
 def get_directory_filenames_with_subdirectories(directory_path):
+    """ Returns a a dictionary of filenames from a directory hierarchy. """
     output = []
     for item in listdir(directory_path):
-        i = {'name': item, 'label': file_to_label(item)}
+        i = {'name': item, 'label': _file_to_label(item)}
         this_path = join(directory_path, item)
         if isfile(this_path):
             i['type'] = 'file'
@@ -160,7 +158,7 @@ def get_directory_filenames_with_subdirectories(directory_path):
     return output
 
 
-def remove_extension_from_filename(filename_string):
+def _remove_extension_from_filename(filename_string):
     return splitext(filename_string)[0]
 
 
@@ -188,7 +186,7 @@ def get_wikimedia_image_url_from_title(title):
         for item in base:
             return base[item]["imageinfo"][0]["url"]
         return "https://commons.wikimedia.org/wiki/File:"+title
-    except (UnicodeEncodeError, KeyError, Exception):
+    except (UnicodeEncodeError, KeyError):
         return "https://commons.wikimedia.org/wiki/File:"+title
 
 
@@ -234,7 +232,7 @@ def get_lang(_dict, default=None):
 def item_detail_parse(qid, with_claims=True):
     """Uses the JSON representation of wikidataintegrator to parse the item ID specified (qid)
     and returns a new dictionary of previewing information and a dictionary of property counts"""
-    item = get_item_json(qid)
+    item = wd_int_utils.get_item_json(qid)
     if not item:
         return False
     label = parse_wd_response_by_key(item, 'labels', default="Item {}".format(qid))
@@ -246,14 +244,14 @@ def item_detail_parse(qid, with_claims=True):
         ex_list = []
         categories = []
         claims = get_claims_from_json(item)
-        for pid, claim_dict in sorted(claims.items(), key=lambda x: entity_id_to_int(x[0])):
+        for pid, claim_dict in sorted(claims.items(), key=lambda x: _entity_id_to_int(x[0])):
             value_list = []
             add_to_ex_list = False
             for json_details in claim_dict:
                 val = parse_snak(pid, json_details.get('mainsnak'))
                 if val:
-                    val['references'] = parse_references(json_details)
-                    val['qualifiers'] = parse_qualifiers(json_details)
+                    val['references'] = _parse_references(json_details)
+                    val['qualifiers'] = _parse_qualifiers(json_details)
                     value_list.append(val)
                     if val.get('parse_type') == 'external-id':
                         add_to_ex_list = True
@@ -262,6 +260,7 @@ def item_detail_parse(qid, with_claims=True):
                     elif pid in ['P31', 'P279']:
                         categories.append(val)
             parsed_claim = {'pid': pid, 'values': value_list}
+            # pylint: disable=W0106
             ex_list.append(parsed_claim) if add_to_ex_list else claim_list.append(parsed_claim)
         output_dict['external_links'] = ex_list
         output_dict['claims'] = claim_list
@@ -269,20 +268,20 @@ def item_detail_parse(qid, with_claims=True):
     return output_dict
 
 
-def parse_qualifiers(json_details):
+def _parse_qualifiers(json_details):
     qualifier_set = json_details.get('qualifiers')
-    return parse_snak_set(qualifier_set)
+    return _parse_snak_set(qualifier_set)
 
 
-def parse_references(json_details):
+def _parse_references(json_details):
     reference_list = json_details.get('references')
     if reference_list:
         reference_set = reference_list[0].get('snaks')
-        return parse_snak_set(reference_set)
+        return _parse_snak_set(reference_set)
     return []
 
 
-def parse_snak_set(snak_set):
+def _parse_snak_set(snak_set):
     parsed_snaks = []
     if snak_set:
         for pid, snak_list in snak_set.items():
@@ -295,24 +294,6 @@ def parse_snak_set(snak_set):
                 parsed_snaks.append({'pid': pid, 'values': values})
     return parsed_snaks
 
-
-def get_item_json(qid):
-    """
-    Get item json dictionary from qid
-    Args:
-        qid (str): Wikidata Identifier, ex: "Q1234"
-
-    Returns:
-        Dict: Returned value of WDItemEngine().wd_json_representation
-    """
-    try:
-        item = WDItemEngine(wd_item_id=qid)
-        return item.wd_json_representation
-    except (ValueError, ConnectionAbortedError, Exception):
-        logging.exception("Exception reading QID: %s", qid)
-        return None
-
-
 def get_item_property_counts(qid):
     """
     Count the number of values in a claim by property
@@ -322,7 +303,7 @@ def get_item_property_counts(qid):
     Returns:
         Dict: {k(str): v(int)} where k is Wikidata Property identifier string and v is count
     """
-    selected_item = get_item_json(qid)
+    selected_item = wd_int_utils.get_item_json(qid)
     claims = get_claims_from_json(selected_item)
     counts = {}
     for pid, values in claims.items():
@@ -384,7 +365,7 @@ def parse_snak(pid, snak):
         else:
             val = "Unable To Parse Value {}".format(data_type)
         return {'value': val, 'parse_type': parse_type, 'type': data_type}
-    except (KeyError, Exception):
+    except KeyError:
         logging.exception("Unexpected exception parsing claims.")
         return None
 
@@ -398,10 +379,10 @@ def format_url_from_property(pid, value):
         return prop.get("formatter_url").replace("$1", value)
     return None
 
-def create_query_template(_string):
-    flat_str = flatten_string(_string)
+def _create_query_template(_string):
+    flat_str = _flatten_string(_string)
     return Template(flat_str)
 
 # Register Template Queries Here
-PROPERTY_QUERY_TEMPLATE = create_query_template(PROPERTY_QUERY)
-PROPERTY_ALLOWED_QUALIFIERS_TEMPLATE = create_query_template(PROPERTY_ALLOWED_QUALIFIERS)
+PROPERTY_QUERY_TEMPLATE = _create_query_template(PROPERTY_QUERY)
+PROPERTY_ALLOWED_QUALIFIERS_TEMPLATE = _create_query_template(PROPERTY_ALLOWED_QUALIFIERS)

--- a/wikidp/utils/__init__.py
+++ b/wikidp/utils/__init__.py
@@ -48,14 +48,13 @@ from . import (
 def dedupe_by_key(dict_list, key):
     """
     Remove duplicates from a list based on matching key's value.
+
     Args:
         dict_list (List[Dict]):
         key (str):
 
     Returns (List[Dict]):
-
     """
-
     output = []
     found_values = set()
     for item in dict_list:
@@ -76,13 +75,13 @@ def _file_to_label(filename):
 
 
 def get_pid_from_string(input_string):
-    """ Parse and return a property id from a string value. """
+    """Parse and return a property id from a string value."""
     regex_search = re.search(PROPERTY_REGEX, input_string)
     return regex_search.group() if regex_search else False
 
 
 def get_qid_from_string(input_string):
-    """ Parse and return an item id from a string value. """
+    """Parse and return an item id from a string value."""
     regex_search = re.search(ITEM_REGEX, input_string)
     return regex_search.group() if regex_search else False
 
@@ -90,20 +89,23 @@ def _entity_id_to_int(entity):
     return int(entity[1:])
 
 def get_property(pid):
-    """ Return the first value from a list of properties. """
+    """Return the first value from a list of properties."""
     prop_response = get_property_details_by_pid_list([pid])
     return prop_response[0] if prop_response else None
 
 def convert_list_to_value_string(lst):
     """
-        Arg: lst, ex: ['P31', 'P5', 'P123']
-        Returns: "(wd:P31)(wd:P5)(wd:P123)"
+    Convert a list of values to a string.
+
+    Arg: lst, ex: ['P31', 'P5', 'P123']
+    Returns: "(wd:P31)(wd:P5)(wd:P123)"
     """
     return '(wd:{0})'.format(')(wd:'.join(map(str, lst)))
 
 def get_all_languages():
     """
     Get list of all Wikimedia languages from Wikidata.
+
     Returns (List[Dict[str, str]]):
 
     Examples:
@@ -126,25 +128,25 @@ def get_all_languages():
 
 
 def get_all_qualifier_properties():
-    """ Return all of the qualifiers for a particular property. """
+    """Return all of the qualifiers for a particular property."""
     query = _flatten_string(ALL_QUALIFIER_PROPERTIES)
     return wd_int_utils.process_query_string(query)
 
 
 def get_allowed_qualifiers_by_pid(pid):
-    """ Return all legal quailifiers for a partiular property. """
+    """Return all legal quailifiers for a partiular property."""
     value = convert_list_to_value_string([pid])
     query = PROPERTY_ALLOWED_QUALIFIERS_TEMPLATE.substitute(values=value)
     return wd_int_utils.process_query_string(query)
 
 def get_property_details_by_pid_list(pid_list):
-    """ Return property details from a property id list. """
+    """Return property details from a property id list."""
     values = convert_list_to_value_string(pid_list)
     query = PROPERTY_QUERY_TEMPLATE.substitute(values=values)
     return wd_int_utils.process_query_string(query)
 
 def get_directory_filenames_with_subdirectories(directory_path):
-    """ Returns a a dictionary of filenames from a directory hierarchy. """
+    """Return a a dictionary of filenames from a directory hierarchy."""
     output = []
     for item in listdir(directory_path):
         i = {'name': item, 'label': _file_to_label(item)}
@@ -163,7 +165,7 @@ def _remove_extension_from_filename(filename_string):
 
 
 def time_formatter(time):
-    """Converts wikidata's time json to a human readable string"""
+    """Convert wikidata's time json to a human readable string."""
     try:
         formatted_time = datetime.strptime(time, '+%Y-%m-%dT%H:%M:%SZ')
         return formatted_time.strftime("%A, %B %-d, %Y")
@@ -192,7 +194,8 @@ def get_wikimedia_image_url_from_title(title):
 
 def parse_wd_response_by_key(item, key, default=None):
     """
-    Parse WikiData Response dictionary into a python list of values
+    Parse WikiData Response dictionary into a python list of values.
+
     Args:
         item (dict): Returned output of using wikidataintegrator's wd_json_representation
         key (str): Desired key to extract values of from item
@@ -213,13 +216,13 @@ def parse_wd_response_by_key(item, key, default=None):
 
 def get_lang(_dict, default=None):
     """
-    Get language value of a dictionary, fallback language if not available
+    Get language value of a dictionary, fallback language if not available.
+
     Args:
         _dict (dict): Dictionary for getting value
         default (optional): Expected return if value does not exist for fallback language
 
     Returns: value of dictionary's language key or default
-
     """
     if not _dict:
         pass
@@ -231,8 +234,11 @@ def get_lang(_dict, default=None):
 
 # pylint: disable=R0914
 def item_detail_parse(qid, with_claims=True):
-    """Uses the JSON representation of wikidataintegrator to parse the item ID specified (qid)
-    and returns a new dictionary of previewing information and a dictionary of property counts"""
+    """
+    Use the JSON representation of wikidataintegrator to parse the item ID specified.
+
+    Returns a new dictionary of previewing information and a dictionary of property counts.
+    """
     item = wd_int_utils.get_item_json(qid)
     if not item:
         return False
@@ -297,7 +303,8 @@ def _parse_snak_set(snak_set):
 
 def get_item_property_counts(qid):
     """
-    Count the number of values in a claim by property
+    Count the number of values in a claim by property.
+
     Args:
         qid (str): Wikidata Identifier, ex: "Q1234"
 
@@ -314,7 +321,8 @@ def get_item_property_counts(qid):
 
 def get_claims_from_json(item_json):
     """
-    Get claim dictionary from WD Item Json Representation
+    Get claim dictionary from WD Item Json Representation.
+
     Args:
         item_json (dict): Returned value of WDItemEngine().wd_json_representation
 
@@ -326,8 +334,7 @@ def get_claims_from_json(item_json):
 
 # pylint: disable=R0912
 def parse_snak(pid, snak):
-    """ Uses the json_details dictionary of a single claim and outputs
-    the parsed data into the output_dict. """
+    """Use a claim's json_details and output the parsed data into the output_dict."""
     try:
         if snak['snaktype'] == 'novalue' or 'datavalue' not in snak:
             return None
@@ -373,8 +380,12 @@ def parse_snak(pid, snak):
 
 
 def format_url_from_property(pid, value):
-    """Inputs property identifier (P###) for a given url type, looks up that
-    wikidata property id's url format (P1630) and creates a url with the value using the format"""
+    """
+    Input property identifier (P###) for a given url type.
+
+    Looks up that wikidata property id's url format (P1630) and creates a url
+    with the value using the format.
+    """
     value = value.strip()
     prop = get_property(pid)
     if 'formatter_url' in prop:

--- a/wikidp/utils/__init__.py
+++ b/wikidp/utils/__init__.py
@@ -229,6 +229,7 @@ def get_lang(_dict, default=None):
     return _dict.get(FALLBACK_LANG, default)
 
 
+# pylint: disable=R0914
 def item_detail_parse(qid, with_claims=True):
     """Uses the JSON representation of wikidataintegrator to parse the item ID specified (qid)
     and returns a new dictionary of previewing information and a dictionary of property counts"""
@@ -323,6 +324,7 @@ def get_claims_from_json(item_json):
     return item_json.get('claims', {})
 
 
+# pylint: disable=R0912
 def parse_snak(pid, snak):
     """ Uses the json_details dictionary of a single claim and outputs
     the parsed data into the output_dict. """

--- a/wikidp/utils/wd_int_utils.py
+++ b/wikidp/utils/wd_int_utils.py
@@ -11,12 +11,12 @@
 #
 # This is a python __init__ script to create the app and import the
 # main package contents
-""" Module to hold all WikiDataIntegrator routines for dependency management. """
+"""Module to hold all WikiDataIntegrator routines for dependency management."""
 import logging
 from wikidataintegrator.wdi_core import WDItemEngine
 
 def process_query_string(query):
-    """ Use WikiDataIntegrator Engine to process a SPARQL Query. """
+    """Use WikiDataIntegrator Engine to process a SPARQL Query."""
     result = WDItemEngine.execute_sparql_query(query)
     bindings = result['results'].get('bindings')
     return _format_wikidata_bindings(bindings)
@@ -26,7 +26,8 @@ def _format_wikidata_bindings(bindings):
 
 def get_item_json(qid):
     """
-    Get item json dictionary from qid
+    Get item json dictionary from qid.
+
     Args:
         qid (str): Wikidata Identifier, ex: "Q1234"
 

--- a/wikidp/utils/wd_int_utils.py
+++ b/wikidp/utils/wd_int_utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2017
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+# This is a python __init__ script to create the app and import the
+# main package contents
+""" Module to hold all WikiDataIntegrator routines for dependency management. """
+import logging
+from wikidataintegrator.wdi_core import WDItemEngine
+
+def process_query_string(query):
+    """ Use WikiDataIntegrator Engine to process a SPARQL Query. """
+    result = WDItemEngine.execute_sparql_query(query)
+    bindings = result['results'].get('bindings')
+    return _format_wikidata_bindings(bindings)
+
+def _format_wikidata_bindings(bindings):
+    return [{k: v.get('value') for k, v in res.items()} for res in bindings]
+
+def get_item_json(qid):
+    """
+    Get item json dictionary from qid
+    Args:
+        qid (str): Wikidata Identifier, ex: "Q1234"
+
+    Returns:
+        Dict: Returned value of WDItemEngine().wd_json_representation
+    """
+    try:
+        item = WDItemEngine(wd_item_id=qid)
+        return item.wd_json_representation
+    except (ValueError, ConnectionAbortedError):
+        logging.exception("Exception reading QID: %s", qid)
+        return None


### PR DESCRIPTION
- added plenty of PyDoc;
- added `_` to front of private method names so no PyDoc required;
- removed general exception catches;
- fixed indentation errors;
- tidied unnecessary imports;
- removed `TODOs`;
- added code header with copyright;
- disabled a few discrete `pylint` warnings; and
- amateur tidying of module structure.