### PR TITLE
FEAT - WDI OAuth as Flask Blueprint

### DIFF
--- a/wikidp/routes/oauth.py
+++ b/wikidp/routes/oauth.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+# coding=UTF-8
+#
+# WikiDP Wikidata Portal
+# Copyright (C) 2020
+# All rights reserved.
+#
+# This code is distributed under the terms of the GNU General Public
+# License, Version 3. See the text file "COPYING" for further details
+# about the terms of this license.
+#
+"""All things OAuth."""
+import os
+import jsonpickle
+
+from flask import Blueprint, session, redirect, request
+from mwoauth import AccessToken
+from wikidataintegrator import wdi_login
+
+# OAuth stuff
+ORG_TOKEN = os.environ.get('CONSUMER_TOKEN', '')
+SECRET_TOKEN = os.environ.get('SECRET_TOKEN', '')
+CB_URL = os.environ.get('OAUTH_CB', 'oob')
+SESSKY_AUTH='authOBJ'
+HOST=os.environ.get('HOST', 'oob')
+
+USER_AGENT = 'wikidp-portal/0.0 (https://wikidp.org/portal/; admin@wikidp.org)'
+
+class WDPOAuth:
+    def __init__(self,
+                 consumer_key=ORG_TOKEN,
+                 consumer_secret=SECRET_TOKEN,
+                 cb_url=CB_URL,
+                 user_agent=USER_AGENT,
+                 **kwargs):
+
+        self.bp = Blueprint('wdpoauth', __name__, **kwargs)
+        self.consumer_key=consumer_key
+        self.consumer_secret=consumer_secret
+        self.cb_url=cb_url
+        self.user_agent=user_agent
+
+        @self.bp.route("/mwoauth/initiate/")
+        def mwoauth_initiate():
+            authentication = wdi_login.WDLogin(self.consumer_key,
+                                               self.consumer_secret,
+                                               self.cb_url,
+                                               self.user_agent)
+            session[SESSKY_AUTH] = jsonpickle.encode(authentication)
+            return redirect(authentication.redirect)
+
+        @self.bp.route("/mwoauth/callback/")
+        def mwoauth_callback():
+            authentication = jsonpickle.decode(session[SESSKY_AUTH])
+            authentication.continue_oauth(request.url)
+            access_token = AccessToken(authentication.s.auth.client.resource_owner_key,
+                                       authentication.s.auth.client.resource_owner_secret)
+            identity = authentication.handshaker.identify(access_token)
+            session["username"]=identity['username']
+            session["userid"]=identity['sub']
+            # return jsonify(body)

--- a/wikidp/routes/pages.py
+++ b/wikidp/routes/pages.py
@@ -5,8 +5,6 @@ import os
 import json
 import jsonpickle
 
-from mwoauth import AccessToken
-
 from flask import (
     abort,
     jsonify,
@@ -26,15 +24,6 @@ from wikidp.controllers.pages import (
     get_item_context,
 )
 
-# OAuth stuff
-ORG_TOKEN = os.environ.get('CONSUMER_TOKEN', '')
-SECRET_TOKEN = os.environ.get('SECRET_TOKEN', '')
-
-USER_AGENT = 'wikidp-portal/0.0 (https://wikidp.org/portal/; admin@wikidp.org)'
-
-# MWOAUTH = MWOAuth(consumer_key=ORG_TOKEN, consumer_secret=SECRET_TOKEN,
-#                   user_agent=USER_AGENT, default_return_to="/profile")
-# APP.register_blueprint(MWOAUTH.bp)
 @APP.route("/")
 def route_page_welcome():
     """Landing Page for first time."""
@@ -78,33 +67,8 @@ def logout():
     session.clear()
     return redirect("profile", code=303)
 
-@APP.route("/profile", methods=['POST', 'GET'])
+@APP.route("/profile")
 def profile():
-    """Flask OAuth login."""
-    if request.method == 'POST':
-        body = json.loads(request.get_data())
-        if 'initiate' in body.keys():
-            authentication = wdi_login.WDLogin(consumer_key=ORG_TOKEN,
-                                               consumer_secret=SECRET_TOKEN,
-                                               callback_url=request.url_root + "profile",
-                                               user_agent=USER_AGENT)
-            session['authOBJ'] = jsonpickle.encode(authentication)
-            response_data = {
-                'wikimediaURL': authentication.redirect
-            }
-            return jsonify(response_data)
-
-        # parse the url from wikidata for the oauth token and secret
-        if 'url' in body.keys():
-            authentication = jsonpickle.decode(session['authOBJ'])
-            authentication.continue_oauth(oauth_callback_data=body['url'].encode("utf-8"))
-            access_token = AccessToken(authentication.s.auth.client.resource_owner_key,
-                                       authentication.s.auth.client.resource_owner_secret)
-            identity = authentication.handshaker.identify(access_token)
-            session["username"]=identity['username']
-            session["userid"]=identity['sub']
-            return jsonify(body)
-
     return render_template('profile.html', username=session.get('username', None))
 
 @APP.route("/unauthorized")


### PR DESCRIPTION
- moved oauth logic to a dedicated `wikidp/routes/oauth.py` module;
  * implements the OAuth "dance" as a series of GET methods;
  * threads OAuth through WDI without changing any APIs;
  * uses the [Flask mwoauth Blueprint project](https://github.com/mediawiki-utilities/python-mwoauth/) as a model;
  * specifically look at the [mwoauth/flask.py module](https://github.com/mediawiki-utilities/python-mwoauth/blob/master/mwoauth/flask.py) to see the direction;
- removed OAuth cruft from `wikidp/routes/pages.py`.

[This set of Flask examples](https://github.com/mediawiki-utilities/python-mwoauth/blob/master/examples/flask_server.py) shows how this implementation could be used by @kennethsn to control login and secure particular functionality using a simple blueprint and annotations.