### PR TITLE
FIX: Item Page with Search Result Deep-linking URLs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python wikidp/__init__.py
+web: flask run

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: flask run --port=${PORT}
+web: gunicorn wikidp:APP

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: flask run
+web: flask run --port=${PORT}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ setuptools
 flask>=1.1.2
 wikidataintegrator==0.6.5
 lxml==4.5.1
+jsonpickle==1.4.1
 numpy==1.19.0
 pandas==1.0.5
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pandas==1.0.5
 python-dateutil==2.8.1
 flask-mwoauth>=0.4.82
 tqdm==4.47.0
+gunicorn==19.9.0
 validators==0.15.0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -128,22 +128,18 @@ def test_route_item_checklist_by_schema__fake_schema(client):
 # FORMS TEST
 def test_route_form_preview_item(client):
     """Test the client loads the contribute of sample item  """
-    response = client.post('/preview', follow_redirects=True,
-                           data={'qid': 'Q7715973', 'optionList': '[["Q7715973", "TEST ELEMENT", "test description"]]'})
+    data = {'qid': 'Q7715973', 'optionList': '["Q7715973"]'}
+    response = client.post('/preview', follow_redirects=True, data=data)
     assert response.status_code == 200
     assert b'Q7715973' in response.data
-    assert b'TEST ELEMENT' in response.data
-    assert b'test description' in response.data
 
 
 def test_route_form_contribute_item(client):
     """Test the client loads the contribute of sample item  """
-    response = client.post('/contribute', follow_redirects=True,
-                           data={'qid': 'Q7715973', 'optionList': '[["Q7715973", "TEST ELEMENT", "test description"]]'})
+    data = {'qid': 'Q7715973', 'optionList': '["Q7715973"]'}
+    response = client.post('/contribute', follow_redirects=True, data=data)
     assert response.status_code == 200
     assert b'Q7715973' in response.data
-    assert b'TEST ELEMENT' in response.data
-    assert b'test description' in response.data
 
 
 # SEARCH TESTS
@@ -163,14 +159,14 @@ def test_route_process_site_search__by_puid(client):
 
 def test_route_site_search__by_label(client):
     """Test the client loads the contribute of sample item  """
-    response = client.get('/search?string=debian')
+    response = client.get('/search?q=debian')
     assert response.status_code == 200
     assert b'Q7715973' in response.data
 
 
 def test_route_site_search__by_puid(client):
     """Test the client loads the contribute of sample item  """
-    response = client.get('/search?string=fmt/354', follow_redirects=True)
+    response = client.get('/search?q=fmt/354', follow_redirects=True)
     assert response.status_code == 200
     assert b'Q26543628' in response.data
 

--- a/wikidp/controllers/api.py
+++ b/wikidp/controllers/api.py
@@ -66,14 +66,26 @@ def load_schema(schema_name):
         with open(SCHEMA_DIRECTORY_PATH+schema_name) as data_file:
             return json.load(data_file)
     except FileNotFoundError:
-        return False
+        return None
 
 
 def get_schema_properties(schema_name):
-    """Get all of the properties of a particular schema."""
+    """
+    Get property constraints of a particular schema.
+
+    Args:
+        schema_name (str): Relative file name of schema.
+
+    Examples:
+        >>> get_schema_properties('file_format_id_pattern')
+        { "P31": {}, "P279": {}, ... }
+
+    Returns (Optional[Dict[str, Dict]]]):
+
+    """
     data = load_schema(schema_name)
-    if data is False:
-        return False
+    if not data:
+        return None
     props = []
     for shape in data.get('shapes', []):
         shape_expression = shape.get('expression')

--- a/wikidp/controllers/pages.py
+++ b/wikidp/controllers/pages.py
@@ -12,32 +12,35 @@
 # This is a python __init__ script to create the app and import the
 # main package contents
 """Module for WikiDP pages."""
-from flask import (
-    json,
-    request,
-)
+from flask import request
 
 from wikidp.controllers.api import get_property_checklist_from_schema
 from wikidp.utils import (
-    item_detail_parse,
     get_directory_filenames_with_subdirectories,
     get_item_property_counts,
+    item_detail_parse,
 )
 
 SCHEMA_DIRECTORY_PATH = 'wikidp/schemas/'
 
 
 def get_item_context(qid, with_claims=True):
-    """Retrieve an item by QID with accompaying claims if requested."""
+    """
+    Retrieve an item by QID with accompanying claims if requested.
+
+    Args:
+        qid (str):
+        with_claims (bool):
+
+    Returns (Tuple[dict, Optional[list], Optional[list]]):
+
+    """
     selected_item = item_detail_parse(qid, with_claims=with_claims)
     options = None
     schemas = None
     if selected_item:
-        options = request.args.get('options', default=0, type=str)
-        if isinstance(options, str):
-            options = json.loads(options)
-        else:
-            options = [[qid, selected_item.get('label'), selected_item.get('description')]]
+        _options = request.args.get('options', default=None, type=str)
+        options = _options.split(',') if _options else [qid]
         schemas = get_schema_list()
     return selected_item, options, schemas
 

--- a/wikidp/models.py
+++ b/wikidp/models.py
@@ -164,8 +164,7 @@ class FileFormatExtSearchResult(PuidSearchResult):
 
     def __init__(self, wd_id, label, description):
         """Constructor for a File Format Extension search result instance."""
-        super().__init__(wd_id, label,
-                                                        description, None, None)
+        super().__init__(wd_id, label, description, None, None)
 
     @staticmethod
     def _build_query(search_string="", lang="en"):

--- a/wikidp/routes/api.py
+++ b/wikidp/routes/api.py
@@ -53,6 +53,22 @@ def route_api_get_item_summary(qid):
     return jsonify(item)
 
 
+@APP.route("/api/items", methods=['GET', 'POST'])
+def route_api_get_item_summary_list():
+    """
+    Get a list of Wikidata Item.
+
+    Returns (Response): JSON list with id, label, description, and aliases
+
+    """
+    if request.method == 'GET':
+        qids = request.args.get('qids').split(',')
+    else:
+        qids = request.get_json()
+    items = [item_detail_parse(qid, with_claims=False) for qid in qids]
+    return jsonify(items)
+
+
 @APP.route("/api/<item:qid>/claims/write", methods=['POST'])
 def route_api_write_claims_to_item(qid):
     """User posts a JSON object of claims to contribute to an item."""

--- a/wikidp/routes/forms.py
+++ b/wikidp/routes/forms.py
@@ -16,18 +16,43 @@ from flask import (
     redirect,
     request,
 )
+import json
+
 from wikidp.config import APP
+
+
+def _get_page_redirect(action):
+    """
+    Get the Redirect with Formatted Deep-linking.
+
+    Args:
+        action (Literal['contribute', 'preview']):
+
+    Returns (Response):
+
+    """
+    qid = request.form['qid']
+    options = ",".join(json.loads(request.form['optionList']))
+    return redirect(f'/{qid}/{action}?qid={qid}&options={options}')
 
 
 @APP.route("/preview", methods=['POST'])
 def route_form_preview_item():
-    """Show a preview of a selected search result."""
-    return redirect('/'+request.form['qid']+'/preview'+'?options='+request.form['optionList'])
+    """
+    Show a preview of a selected search result.
+
+    Returns (Response):
+
+    """
+    return _get_page_redirect('preview')
 
 
 @APP.route("/contribute", methods=['POST'])
 def route_form_contribute_item():
-    """Process contribute page into a state-saving url."""
-    qid = request.form['qid']
-    return redirect('/{qid}/contribute?qid={qid}&options={opts}'
-                    .format(qid=qid, opts=request.form['optionList']))
+    """
+    Process contribute page into a state-saving url.
+
+    Returns (Response):
+
+    """
+    return _get_page_redirect('contribute')

--- a/wikidp/routes/forms.py
+++ b/wikidp/routes/forms.py
@@ -12,11 +12,12 @@
 # This is a python __init__ script to create the app and import the
 # main package contents
 """Module for application form routes."""
+import json
+
 from flask import (
     redirect,
     request,
 )
-import json
 
 from wikidp.config import APP
 

--- a/wikidp/routes/pages.py
+++ b/wikidp/routes/pages.py
@@ -32,6 +32,7 @@ SECRET_TOKEN = os.environ.get('SECRET_TOKEN', '')
 
 USER_AGENT = 'wikidp-portal/0.0 (https://wikidp.org/portal/; admin@wikidp.org)'
 
+
 # MWOAUTH = MWOAuth(consumer_key=ORG_TOKEN, consumer_secret=SECRET_TOKEN,
 #                   user_agent=USER_AGENT, default_return_to="/profile")
 # APP.register_blueprint(MWOAUTH.bp)
@@ -59,6 +60,7 @@ def route_page_reports():
     """Render the reports page."""
     return render_template('reports.html')
 
+
 @APP.route("/auth")
 def authenication():
     """Return the authorisation status as JSON."""
@@ -72,11 +74,13 @@ def authenication():
         }
     return jsonify(response_data)
 
+
 @APP.route("/logout")
 def logout():
     """Clear out session variables and redirect to profile display."""
     session.clear()
     return redirect("profile", code=303)
+
 
 @APP.route("/profile", methods=['POST', 'GET'])
 def profile():
@@ -101,11 +105,12 @@ def profile():
             access_token = AccessToken(authentication.s.auth.client.resource_owner_key,
                                        authentication.s.auth.client.resource_owner_secret)
             identity = authentication.handshaker.identify(access_token)
-            session["username"]=identity['username']
-            session["userid"]=identity['sub']
+            session["username"] = identity['username']
+            session["userid"] = identity['sub']
             return jsonify(body)
 
     return render_template('profile.html', username=session.get('username', None))
+
 
 @APP.route("/unauthorized")
 def route_page_unauthorized():

--- a/wikidp/routes/search.py
+++ b/wikidp/routes/search.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/python
 # coding=UTF-8
 #
@@ -20,8 +19,14 @@ from wikidp.controllers import search as search_controller
 
 @APP.route("/search", methods=['POST'])
 def route_process_site_search():
-    """Process a search request into a state-saving url."""
-    return redirect('/search?string='+request.form['userInput'].strip())
+    """
+    Process a search request into a state-saving url.
+
+    Returns (Response):
+
+    """
+    query = request.form['userInput'].strip()
+    return redirect(f'/search?q={query}')
 
 
 @APP.route("/search")
@@ -29,12 +34,17 @@ def route_site_search():
     """
     Display the most likely results of a users search.
 
-    if only one result returned, the user is automatic redirected to preview that item.
+    Notes:
+        if only one result returned,
+        then user is automatic redirected to preview that item.
+
+    Returns (Response):
+
     """
-    search_string = request.args.get('string', default=0, type=str)
+    search_string = request.args.get('q', default='', type=str)
     context = search_controller.get_search_result_context(search_string)
     if len(context) == 1:
-        return redirect('/{}'.format(context[0].get('qid')))
+        return redirect(f'/{context[0]["qid"]}')
     return render_template('search_results.html', options=context)
 
 

--- a/wikidp/templates/item.html
+++ b/wikidp/templates/item.html
@@ -40,9 +40,12 @@
 {% endblock page_content %}
 
 {% block page_scripts %}
+  <script type="text/javascript">
+    const QID_OPTIONS = {{ options|tojson }};
+  </script>
     {% include "snippets/item_templates.html" %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
-    <script src="{{ url_for('static', filename='js/item.js') }}" type="text/javascript"></script>
+    <script src="{{ url_for('static', filename='js/item.js', cb="20201113") }}" type="text/javascript"></script>
     {% block item_page_scripts %}
     {% endblock item_page_scripts %}
 {% endblock page_scripts %}

--- a/wikidp/templates/search_results.html
+++ b/wikidp/templates/search_results.html
@@ -54,12 +54,12 @@ form.submit();
       _options.push($(this).data('qid'));
     });
     const options = JSON.stringify(_options);
-    const formHTML = ```
+    const formHTML = `
       <form action="/preview" method="post">
         <input type="text" name="qid" value="${qid}" />
         <input type="text" name="optionList" value=${options} />
       </form>
-    ```;
+    `;
     const $form = $(formHTML).hide(0);
     pageTransition($form);
   }

--- a/wikidp/templates/search_results.html
+++ b/wikidp/templates/search_results.html
@@ -48,23 +48,21 @@
 form.submit();
 })
 }
-	function selectResult(qid){
-		var list = $('li.option-li')
-		var options = []
-		for (i = 0; i < list.length; i++){
-			// console.log($(list[i]).data('qid'), $(list[i]).data('label'))
-			options.push([$(list[i]).data('qid'), $(list[i]).data('label'), $(list[i]).data('description') ])
-		}
-		options = JSON.stringify(options)
-		// console.log(options)
-		// console.log(qid)
-		var form = $('<form action="/preview" method="post">' +
-  						'<input type="text" name="qid" value="' + qid + '" />' +
-  						'<input type="text" name="optionList" '+"value='"+options+"' />" +
-  					'</form>').hide(0);
-		pageTransition(form);
-		// return $.post("/preview", {qid:qid})
-	}
+  const selectResult = (qid) => {
+    const _options = [];
+    $('.option-li').each(function() {
+      _options.push($(this).data('qid'));
+    });
+    const options = JSON.stringify(_options);
+    const formHTML = ```
+      <form action="/preview" method="post">
+        <input type="text" name="qid" value="${qid}" />
+        <input type="text" name="optionList" value=${options} />
+      </form>
+    ```;
+    const $form = $(formHTML).hide(0);
+    pageTransition($form);
+  }
 
 </script>
 {% endblock page_content %}

--- a/wikidp/templates/snippets/item_sidebar.html
+++ b/wikidp/templates/snippets/item_sidebar.html
@@ -16,15 +16,9 @@
     <!-- selected item -->
     <div class="selected-item-div">
         <label class="sidebar-header" for="option-select">selected item</label>
-        <select id="option-select" class="text-medium"  aria-label="Select an alternative wikidata item option">
-            {% for option in options %}
-                <option class="item-option" data-qid="{{option[0]}}" data-label="{{option[1]}}" title="{{option[2]}}"
-                        data-description="{{option[2]}}" value="{{option[0]}}"
-                        {% if option[0] == item.qid %}selected{% endif %}>
-                    {{option[1]}}<span class="select-item-id"> ({{option[0]}})</span>
-                </option>
-            {% endfor %}
-        </select>
+        <div id="item-options-container">
+          <i class="fa fa-spinner fa-spin"></i> Loading
+        </div>
     </div>
     <!-- schema gallery -->
     <div class="schema-gallery-div">

--- a/wikidp/templates/snippets/item_templates.html
+++ b/wikidp/templates/snippets/item_templates.html
@@ -5,4 +5,26 @@
             <input type="text" name="optionList" value="{{options}}"/>
         </form>
     </script>
+  <script
+    id="wikidp-item-options"
+    type="text/template"
+  >
+    <select
+      aria-label="Select an alternative wikidata item option"
+      class="text-medium"
+      id="option-select"
+    >
+      {{#options}}
+        <option
+          class="item-option"
+          data-label="{{ label }}"
+          data-qid="{{ qid }}"
+          title="{{ description }}"
+          value="{{ qid }}"
+        >
+          {{ label }} ({{ qid }})
+        </option>
+      {{/options}}
+    </select>
+  </script>
 {% endraw %}


### PR DESCRIPTION
**Context**
Users reported that searching 'pdf' causes a server error.
**Problem**
This is because the context of the deep-linking url is too long. 
**Fix**
- Lazy-load the search result selector for an item page
- API Endpoint to get label/description by list of QIDs
- Reduce URL params to just comma-separated QIDs, not full metadata
![Screen Shot 2020-11-13 at 2 31 37 PM](https://user-images.githubusercontent.com/22854770/99127367-f934d280-25bc-11eb-8fae-4880898b2f13.png)
